### PR TITLE
fix(input): Esc 绑定改为 paste_now，避免误弹多行粘贴确认

### DIFF
--- a/nebula_app/src/input/mod.rs
+++ b/nebula_app/src/input/mod.rs
@@ -223,7 +223,10 @@ impl<T: EventListener> Execute<T> for Action {
     #[inline]
     fn execute<A: ActionContext<T>>(&self, ctx: &mut A) {
         match self {
-            Action::Esc(s) => ctx.paste(s, false),
+            // Esc/chars bindings are keystroke sequences (e.g. Shift+Enter → ESC+CR for
+            // Claude Code multiline), not clipboard pastes. paste() gates on \r/\n and
+            // would pop the multi-line confirm modal, so write through paste_now.
+            Action::Esc(s) => ctx.paste_now(s, false),
             Action::Command(program) => ctx.spawn_daemon(program.program(), program.args()),
             Action::Hint(hint) => {
                 ctx.display().hint_state.start(hint.clone());


### PR DESCRIPTION
## 摘要
- 将 `Action::Esc` 从 `paste` 改为 `paste_now`
- 避免 Esc/字符序列（如 Shift+Enter → ESC+CR，用于 Claude Code 多行输入）被当成剪贴板粘贴，从而弹出多行确认框

## 原因
`Action::Esc` 表示的是按键序列，不是剪贴板内容。`paste()` 会对 `\r`/`\n` 做门控并弹出 multi-line confirm modal，导致快捷键行为异常。

## 变更
- `nebula_app/src/input/mod.rs`：`Action::Esc(s) => ctx.paste_now(s, false)`

## 测试计划
- [ ] 使用 Shift+Enter（或其它 Esc 序列绑定）发送多行输入
- [ ] 确认不会弹出 multi-line paste 确认框
- [ ] 确认普通剪贴板多行粘贴行为不变
- [ ] 确认其它 `Action::Esc` 绑定仍能正确写入终端