### PR TITLE
feat: Windows system-font picker with search box

### DIFF
--- a/nebula_app/src/display/mod.rs
+++ b/nebula_app/src/display/mod.rs
@@ -1460,6 +1460,9 @@ pub struct Display {
     /// 字体目录的搜索串。匹配列表上显示的那个名字，不维护跨语言别名。
     /// 只在下拉打开期间存在，关闭即清空，不持久化。
     nebula_font_query: String,
+    /// 搜索框的光标与选区。与图标搜索框、SSH 表单字段共用同一套模型：
+    /// 新加的输入框继承行为，不必再实现一遍。
+    nebula_font_query_cursor: ui::text_field::TextCursor,
     /// 目录中被判定为非等宽的族（小写名）。界面据此给比例字体警告——
     /// 固定网格下它们可能重叠或截断，但用户知情后仍可选择。
     nebula_font_proportional: std::collections::HashSet<String>,
@@ -2002,6 +2005,7 @@ impl Display {
             nebula_system_fonts: None,
             nebula_font_show_all: false,
             nebula_font_query: String::new(),
+            nebula_font_query_cursor: Default::default(),
             nebula_font_proportional: std::collections::HashSet::new(),
             nebula_font_notice: font_notice,
             nebula_tab_labels: vec![".".to_owned()],
@@ -3019,6 +3023,7 @@ impl Display {
             font_notice: self.nebula_font_notice.clone(),
             font_show_all: self.nebula_font_show_all,
             font_query: self.nebula_font_query.clone(),
+            font_query_cursor: self.nebula_font_query_cursor.clone(),
             font_proportional: self.nebula_font_proportional.clone(),
             hidden_hosts: self.nebula_hidden_hosts.clone(),
             fetch: self.nebula_fetch_enabled,
@@ -3238,6 +3243,7 @@ impl Display {
         // 搜索是这次展开的临时状态：关掉就清空，下次打开从完整目录开始。
         if !self.nebula_font_query.is_empty() {
             self.nebula_font_query.clear();
+            self.nebula_font_query_cursor = Default::default();
             self.rebuild_font_catalog();
         }
         self.pending_update.dirty = true;
@@ -3423,25 +3429,87 @@ impl Display {
         self.nebula_font_families = families;
     }
 
+    /// 搜索框里文本的起点 x 与单元格宽——鼠标定位光标要用它换算落点。
+    /// 与渲染同源（[`settings::font_search_field_rect`]），两边不会漂。
+    pub fn font_search_text_origin(&self) -> (f32, f32) {
+        let scale = self.window.scale_factor as f32;
+        let cell_w = self.size_info.cell_width();
+        let field = settings::font_search_field_rect(
+            &self.size_info,
+            scale,
+            self.terminal_card_rect(),
+            self.nebula_settings_section,
+            self.nebula_settings_scroll,
+            self.nebula_settings_dropdown,
+            self.font_picker_count(),
+            self.nebula_hidden_hosts.len(),
+        );
+        (field.map_or(0.0, |rect| rect.0 + 12.0 * scale), cell_w)
+    }
+
     pub fn font_query(&self) -> &str {
         &self.nebula_font_query
     }
 
-    pub fn font_query_push(&mut self, ch: char) {
-        if ch.is_control() {
-            return;
+    /// 插入文本，或 `None` 表示退格。查询串一变就重建目录——列表跟着打字走，
+    /// 才是「所见即所搜」。
+    pub fn font_query_edit(&mut self, insert: Option<&str>) {
+        match insert {
+            Some(text) => {
+                let clean: String = text.chars().filter(|ch| !ch.is_control()).collect();
+                if clean.is_empty() {
+                    return;
+                }
+                self.nebula_font_query_cursor.insert(&mut self.nebula_font_query, &clean);
+            },
+            None => self.nebula_font_query_cursor.backspace(&mut self.nebula_font_query),
         }
-        self.nebula_font_query.push(ch);
         self.rebuild_font_catalog();
         self.pending_update.dirty = true;
         self.window.request_redraw();
     }
 
-    pub fn font_query_backspace(&mut self) {
-        if self.nebula_font_query.pop().is_none() {
-            return;
-        }
+    pub fn font_query_delete_forward(&mut self) {
+        self.nebula_font_query_cursor.delete_forward(&mut self.nebula_font_query);
         self.rebuild_font_catalog();
+        self.pending_update.dirty = true;
+        self.window.request_redraw();
+    }
+
+    pub fn font_query_move(&mut self, forward: bool, extend: bool) {
+        let text = self.nebula_font_query.clone();
+        self.nebula_font_query_cursor.step(&text, forward, extend);
+        self.pending_update.dirty = true;
+        self.window.request_redraw();
+    }
+
+    pub fn font_query_jump(&mut self, to_end: bool, extend: bool) {
+        let text = self.nebula_font_query.clone();
+        self.nebula_font_query_cursor.jump(&text, to_end, extend);
+        self.pending_update.dirty = true;
+        self.window.request_redraw();
+    }
+
+    pub fn font_query_select_all(&mut self) {
+        let text = self.nebula_font_query.clone();
+        self.nebula_font_query_cursor.select_all(&text);
+        self.pending_update.dirty = true;
+        self.window.request_redraw();
+    }
+
+    pub fn font_query_selected_text(&self) -> Option<String> {
+        self.nebula_font_query_cursor.selected_text(&self.nebula_font_query)
+    }
+
+    /// 按点击落点定位光标。`offset_x` 是相对文本起点的距离。
+    pub fn font_query_place(&mut self, offset_x: f32, cell_w: f32, extend: bool) {
+        let text = self.nebula_font_query.clone();
+        let index = ui::text_field::index_at(&text, offset_x, cell_w);
+        if extend {
+            self.nebula_font_query_cursor.extend_to(&text, index);
+        } else {
+            self.nebula_font_query_cursor.place(&text, index);
+        }
         self.pending_update.dirty = true;
         self.window.request_redraw();
     }

--- a/nebula_app/src/display/mod.rs
+++ b/nebula_app/src/display/mod.rs
@@ -1460,6 +1460,9 @@ pub struct Display {
     /// 字体目录的搜索串。匹配列表上显示的那个名字，不维护跨语言别名。
     /// 只在下拉打开期间存在，关闭即清空，不持久化。
     nebula_font_query: String,
+    /// 目录中被判定为非等宽的族（小写名）。界面据此给比例字体警告——
+    /// 固定网格下它们可能重叠或截断，但用户知情后仍可选择。
+    nebula_font_proportional: std::collections::HashSet<String>,
     nebula_font_notice: Option<String>,
     /// Optional runtime clear/background color controlled from settings.
     pub nebula_background: Option<Rgb>,
@@ -1701,7 +1704,25 @@ impl Display {
         debug!("Loading \"{}\" font", &settings_init.font_family);
         let font =
             config.font.clone().with_family(settings_init.font_family.clone()).with_size(font_size);
-        let mut glyph_cache = GlyphCache::new(rasterizer, &font)?;
+        // 保存的字体偏好可能在两次启动之间消失（系统字体被卸载、导入文件
+        // 被删）。那种情况本次回退到内置字体并告警，但**保留原偏好**——
+        // 字体恢复可用后，下次启动自动回到用户的选择。
+        let (mut glyph_cache, font_notice) = match GlyphCache::new(rasterizer, &font) {
+            Ok(cache) => (cache, None),
+            Err(error) => {
+                let fallback = config
+                    .font
+                    .clone()
+                    .with_family(crate::font_install::REQUIRED_FONT_FAMILY.to_owned())
+                    .with_size(font_size);
+                let notice = format!(
+                    "字体「{}」本次不可用（{error}），暂用内置字体；偏好已保留。",
+                    settings_init.font_family
+                );
+                let rasterizer = Rasterizer::new()?;
+                (GlyphCache::new(rasterizer, &fallback)?, Some(notice))
+            },
+        };
         glyph_cache.wide_bold_use_regular = settings_init.cjk_bold_regular;
         #[cfg(windows)]
         let mut nebula_font_families = glyph_cache.private_font_families();
@@ -1981,7 +2002,8 @@ impl Display {
             nebula_system_fonts: None,
             nebula_font_show_all: false,
             nebula_font_query: String::new(),
-            nebula_font_notice: None,
+            nebula_font_proportional: std::collections::HashSet::new(),
+            nebula_font_notice: font_notice,
             nebula_tab_labels: vec![".".to_owned()],
             nebula_tab_colors: vec![None],
             nebula_tab_bells: vec![false],
@@ -2997,6 +3019,7 @@ impl Display {
             font_notice: self.nebula_font_notice.clone(),
             font_show_all: self.nebula_font_show_all,
             font_query: self.nebula_font_query.clone(),
+            font_proportional: self.nebula_font_proportional.clone(),
             hidden_hosts: self.nebula_hidden_hosts.clone(),
             fetch: self.nebula_fetch_enabled,
             powerline: self.nebula_powerline_enabled,
@@ -3385,6 +3408,11 @@ impl Display {
             &self.nebula_font_query,
             &self.nebula_font_family,
         );
+        self.nebula_font_proportional = catalog
+            .iter()
+            .filter(|entry| !entry.monospaced)
+            .map(|entry| entry.name.to_lowercase())
+            .collect();
         let mut families: Vec<String> = catalog.into_iter().map(|entry| entry.name).collect();
         // 内置字体永远排在最前，与上游一致。
         families.retain(|family| family != crate::font_install::REQUIRED_FONT_FAMILY);

--- a/nebula_app/src/display/mod.rs
+++ b/nebula_app/src/display/mod.rs
@@ -1452,6 +1452,14 @@ pub struct Display {
     pub nebula_tab_reveal_motion: settings::TabRevealMotion,
     pub nebula_font_family: String,
     nebula_font_families: Vec<String>,
+    /// 系统字体族的惰性缓存：首次展开字体目录时枚举一次，之后复用。
+    /// 放在启动路径上会让每次冷启都付几百个族的等宽查询开销。
+    nebula_system_fonts: Option<Vec<crate::font_install::SystemFontFamily>>,
+    /// 字体目录的「显示全部」临时过滤开关，不持久化。
+    nebula_font_show_all: bool,
+    /// 字体目录的搜索串。匹配列表上显示的那个名字，不维护跨语言别名。
+    /// 只在下拉打开期间存在，关闭即清空，不持久化。
+    nebula_font_query: String,
     nebula_font_notice: Option<String>,
     /// Optional runtime clear/background color controlled from settings.
     pub nebula_background: Option<Rgb>,
@@ -1970,6 +1978,9 @@ impl Display {
             nebula_tab_reveal_motion: settings_init.tab_reveal,
             nebula_font_family: settings_init.font_family,
             nebula_font_families,
+            nebula_system_fonts: None,
+            nebula_font_show_all: false,
+            nebula_font_query: String::new(),
             nebula_font_notice: None,
             nebula_tab_labels: vec![".".to_owned()],
             nebula_tab_colors: vec![None],
@@ -2115,8 +2126,14 @@ impl Display {
         self.nebula_detected_shells.as_ref().map_or(0, Vec::len)
     }
 
+    /// 字体族行 + 两个固定尾行：「显示全部 / 仅等宽」过滤切换，以及「导入字体…」。
     pub fn font_picker_count(&self) -> usize {
-        self.nebula_font_families.len() + 1
+        self.nebula_font_families.len() + 2
+    }
+
+    /// 「显示全部」当前是否开启（供设置页渲染该行的文案）。
+    pub fn font_show_all(&self) -> bool {
+        self.nebula_font_show_all
     }
 
     pub fn hidden_ssh_host_count(&self) -> usize {
@@ -2978,6 +2995,8 @@ impl Display {
             font_size_px: self.font_size.as_px() / self.window.scale_factor as f32,
             fonts: self.nebula_font_families.clone(),
             font_notice: self.nebula_font_notice.clone(),
+            font_show_all: self.nebula_font_show_all,
+            font_query: self.nebula_font_query.clone(),
             hidden_hosts: self.nebula_hidden_hosts.clone(),
             fetch: self.nebula_fetch_enabled,
             powerline: self.nebula_powerline_enabled,
@@ -3193,6 +3212,11 @@ impl Display {
             return false;
         }
         self.nebula_bg_hex_active = false;
+        // 搜索是这次展开的临时状态：关掉就清空，下次打开从完整目录开始。
+        if !self.nebula_font_query.is_empty() {
+            self.nebula_font_query.clear();
+            self.rebuild_font_catalog();
+        }
         self.pending_update.dirty = true;
         self.window.request_redraw();
         true
@@ -3330,7 +3354,76 @@ impl Display {
     }
 
     pub fn toggle_font_picker(&mut self) {
+        // 首次展开才枚举系统字体——这是整个功能里唯一昂贵的一步，放在
+        // 用户已经预期有一次加载的时刻。
+        if self.nebula_settings_dropdown != Some(settings::SettingsDropdown::Font) {
+            self.ensure_font_catalog();
+        }
         self.toggle_settings_dropdown(settings::SettingsDropdown::Font);
+    }
+
+    /// 惰性装配**字体目录**：系统族与导入族合并去重、按当前过滤条件筛选，
+    /// 当前生效字体始终保留。
+    fn ensure_font_catalog(&mut self) {
+        #[cfg(windows)]
+        if self.nebula_system_fonts.is_none() {
+            self.nebula_system_fonts = Some(self.glyph_cache.system_font_families());
+        }
+        self.rebuild_font_catalog();
+    }
+
+    fn rebuild_font_catalog(&mut self) {
+        let system = self.nebula_system_fonts.clone().unwrap_or_default();
+        #[cfg(windows)]
+        let imported = self.glyph_cache.private_font_families();
+        #[cfg(not(windows))]
+        let imported: Vec<String> = Vec::new();
+        let catalog = crate::font_install::font_catalog(
+            &system,
+            &imported,
+            self.nebula_font_show_all,
+            &self.nebula_font_query,
+            &self.nebula_font_family,
+        );
+        let mut families: Vec<String> = catalog.into_iter().map(|entry| entry.name).collect();
+        // 内置字体永远排在最前，与上游一致。
+        families.retain(|family| family != crate::font_install::REQUIRED_FONT_FAMILY);
+        families.insert(0, crate::font_install::REQUIRED_FONT_FAMILY.to_owned());
+        if !families.iter().any(|family| family == &self.nebula_font_family) {
+            families.push(self.nebula_font_family.clone());
+        }
+        self.nebula_font_families = families;
+    }
+
+    pub fn font_query(&self) -> &str {
+        &self.nebula_font_query
+    }
+
+    pub fn font_query_push(&mut self, ch: char) {
+        if ch.is_control() {
+            return;
+        }
+        self.nebula_font_query.push(ch);
+        self.rebuild_font_catalog();
+        self.pending_update.dirty = true;
+        self.window.request_redraw();
+    }
+
+    pub fn font_query_backspace(&mut self) {
+        if self.nebula_font_query.pop().is_none() {
+            return;
+        }
+        self.rebuild_font_catalog();
+        self.pending_update.dirty = true;
+        self.window.request_redraw();
+    }
+
+    /// 切换「显示全部」并重建目录。这是临时过滤，不写入设置。
+    pub fn toggle_font_show_all(&mut self) {
+        self.nebula_font_show_all = !self.nebula_font_show_all;
+        self.ensure_font_catalog();
+        self.pending_update.dirty = true;
+        self.window.request_redraw();
     }
 
     pub fn close_font_picker(&mut self) {
@@ -3343,7 +3436,19 @@ impl Display {
         base.clone().with_family(self.nebula_font_family.clone())
     }
 
+    /// 事务性地切换字体族：先确认它真能加载，成功才更新生效字体与持久化
+    /// 偏好；失败保留原字体与原偏好，并给出可理解的错误。
+    ///
+    /// 上游此前「先持久化再加载」是安全的——那时目录里只有内置字体与已经
+    /// 成功导入过的族，个个都预先验证过。系统字体枚举打破了这个不变量，
+    /// 所以这道预检是本功能自带的安全网，不是顺手修的既有缺陷。
     fn apply_font_family(&mut self, family: String, base: &Font) {
+        if !self.glyph_cache.family_loads(&family, self.font_size) {
+            self.nebula_font_notice = Some(format!("字体无法加载：{family}"));
+            self.pending_update.dirty = true;
+            self.window.request_redraw();
+            return;
+        }
         self.nebula_font_family = family;
         self.nebula_font_notice = None;
         let font = self.effective_font(base).with_size(self.font_size);
@@ -3358,7 +3463,12 @@ impl Display {
             self.nebula_settings_dropdown = None;
             return;
         }
-        if index != self.nebula_font_families.len() {
+        // 倒数第二行：临时过滤切换，不关闭下拉——用户通常要接着挑字体。
+        if index == self.nebula_font_families.len() {
+            self.toggle_font_show_all();
+            return;
+        }
+        if index != self.nebula_font_families.len() + 1 {
             return;
         }
 

--- a/nebula_app/src/display/settings.rs
+++ b/nebula_app/src/display/settings.rs
@@ -1432,6 +1432,10 @@ pub(super) struct SettingsView {
     /// Private families plus Maple; the import action is rendered separately.
     pub(super) fonts: Vec<String>,
     pub(super) font_notice: Option<String>,
+    /// 字体目录的「显示全部」临时过滤是否开启。
+    pub(super) font_show_all: bool,
+    /// 字体目录搜索串；下拉展开且非空时顶替触发器上显示的字体名。
+    pub(super) font_query: String,
     /// Persistent soft-deleted destinations. Rows provide a discoverable
     /// recovery path after the short Undo bar has expired.
     pub(super) hidden_hosts: Vec<String>,
@@ -2588,6 +2592,14 @@ pub(super) fn draw_popup_text(
             },
             SettingsDropdown::Font => match view.fonts.get(index) {
                 Some(family) => family.clone(),
+                // 倒数第二行是过滤切换，最后一行是导入。
+                None if index == view.fonts.len() => {
+                    if view.font_show_all {
+                        language.pick("◉  显示全部字体", "(*) Showing all fonts").to_owned()
+                    } else {
+                        language.pick("○  仅等宽字体", "( ) Monospaced only").to_owned()
+                    }
+                },
                 None => language.pick("＋  导入字体…", "+  Import font...").to_owned(),
             },
             SettingsDropdown::BackgroundFit => {
@@ -3285,7 +3297,14 @@ pub(super) fn draw_text(
                 }
             }
             if visible(geometry.font.1, geometry.font.3) {
-                let font_value = view.font_notice.as_deref().unwrap_or(&view.font_family);
+                // 搜索期间触发器顶替显示查询串——否则用户看不见自己在搜
+                // 什么。加载失败的告警优先于两者。
+                let searching = format!("\u{1f50d} {}", view.font_query);
+                let font_value = match view.font_notice.as_deref() {
+                    Some(notice) => notice,
+                    None if !view.font_query.is_empty() => &searching,
+                    None => &view.font_family,
+                };
                 row_label(
                     r,
                     gc,

--- a/nebula_app/src/display/settings.rs
+++ b/nebula_app/src/display/settings.rs
@@ -1436,6 +1436,8 @@ pub(super) struct SettingsView {
     pub(super) font_show_all: bool,
     /// 字体目录搜索串；下拉展开且非空时顶替触发器上显示的字体名。
     pub(super) font_query: String,
+    /// 非等宽族的小写名集合；下拉行据此追加比例字体警告。
+    pub(super) font_proportional: std::collections::HashSet<String>,
     /// Persistent soft-deleted destinations. Rows provide a discoverable
     /// recovery path after the short Undo bar has expired.
     pub(super) hidden_hosts: Vec<String>,
@@ -2591,6 +2593,11 @@ pub(super) fn draw_popup_text(
                 if program.is_empty() { name.clone() } else { format!("{name}  ·  {program}") }
             },
             SettingsDropdown::Font => match view.fonts.get(index) {
+                // 比例字体在固定终端网格下可能重叠或截断：标出来，但不拦着
+                // 用户选——这是知情选择，不是错误。
+                Some(family) if view.font_proportional.contains(&family.to_lowercase()) => {
+                    format!("{family}   {}", language.pick("· 非等宽", "· not monospaced"))
+                },
                 Some(family) => family.clone(),
                 // 倒数第二行是过滤切换，最后一行是导入。
                 None if index == view.fonts.len() => {

--- a/nebula_app/src/display/settings.rs
+++ b/nebula_app/src/display/settings.rs
@@ -25,7 +25,7 @@ use crate::renderer::{GlyphCache, Renderer};
 
 use super::keymap;
 use super::ui::theme::Skin;
-use super::ui::{icons, widgets};
+use super::ui::{icons, surface, text_field, widgets};
 use super::{
     AcceptKey, LanguagePreference, NebulaShell, NebulaTheme, SizeInfo, UiLanguage,
     chrome_settings_button_rect, contains_rect, nebula_data_dir, truncate_tab_label,
@@ -224,6 +224,8 @@ pub enum SettingsHit {
     FontCycle,
     /// Imported-font picker rows; the final row is always "导入字体…".
     FontPickerRow(usize),
+    /// 字体弹层顶部的搜索框。点它是定位光标，不是关掉弹层。
+    FontSearchField,
     /// Font-size spinner steppers on the "字号" row.
     FontSizeUp,
     FontSizeDown,
@@ -1119,6 +1121,19 @@ pub(super) fn background_color_popup(
     BackgroundColorPopup { rect: (x, y, w, h), swatch, hex }
 }
 
+/// 字体弹层的总行数：候选行 + 顶部那个搜索框。
+///
+/// 一个字体都筛不出来时仍然是 1 行——那时搜索框是弹层里唯一的东西，也正是
+/// 用户要用来改查询串的那一个。
+pub(super) fn font_popup_row_count(font_rows: usize) -> usize {
+    font_rows + 1
+}
+
+/// 弹层第 `row` 行对应第几个候选。`None` = 那是搜索框。
+pub(super) fn font_popup_slot(row: usize) -> Option<usize> {
+    row.checked_sub(1)
+}
+
 fn dropdown_anchor(
     geometry: &SettingsGeometry,
     section: NebulaSettingsSection,
@@ -1131,7 +1146,9 @@ fn dropdown_anchor(
     let anchor = |row| widgets::combobox_rect(row, scale);
     match (section, dropdown) {
         (Section::Profiles, SettingsDropdown::Shell) => Some((anchor(geometry.shell), shell_count)),
-        (Section::Profiles, SettingsDropdown::Font) => Some((anchor(geometry.font), font_count)),
+        (Section::Profiles, SettingsDropdown::Font) => {
+            Some((anchor(geometry.font), font_popup_row_count(font_count)))
+        },
         (Section::Profiles, SettingsDropdown::Accept) => {
             Some((anchor(geometry.accept), ACCEPT_OPTIONS.len()))
         },
@@ -1158,6 +1175,37 @@ fn dropdown_anchor(
 /// same offset the renderer used, so hits land on what the user actually sees;
 /// rows scrolled out of the content viewport don't respond.
 #[allow(clippy::too_many_arguments)]
+/// 字体弹层里搜索框的矩形。命中与渲染各算一遍会漂，所以两边都问这里。
+///
+/// 返回 `None` 表示当前没有展开字体弹层。
+pub fn font_search_field_rect(
+    size_info: &SizeInfo,
+    scale_factor: f32,
+    area: (f32, f32, f32, f32),
+    section: NebulaSettingsSection,
+    scroll: f32,
+    dropdown: Option<SettingsDropdown>,
+    font_count: usize,
+    hidden_host_count: usize,
+) -> Option<(f32, f32, f32, f32)> {
+    if dropdown != Some(SettingsDropdown::Font) {
+        return None;
+    }
+    let geometry = settings_geometry(size_info, scale_factor, area, scroll, hidden_host_count);
+    let s = |v: f32| v * scale_factor;
+    let (_, py, _, ph) = geometry.popup;
+    let (anchor, count) =
+        dropdown_anchor(&geometry, section, SettingsDropdown::Font, 0, font_count, scale_factor)?;
+    let popup = widgets::combobox_popup_rect(
+        anchor,
+        count,
+        scale_factor,
+        geometry.content_top,
+        py + ph - s(6.0),
+    );
+    Some(widgets::popup_row_rect(popup, 0, scale_factor))
+}
+
 pub fn settings_hit(
     size_info: &SizeInfo,
     scale_factor: f32,
@@ -1220,7 +1268,10 @@ pub fn settings_hit(
             if let Some(index) = widgets::popup_row_at(popup, count, scale_factor, x, y) {
                 return match dropdown {
                     SettingsDropdown::Shell => SettingsHit::ShellPickerRow(index),
-                    SettingsDropdown::Font => SettingsHit::FontPickerRow(index),
+                    SettingsDropdown::Font => match font_popup_slot(index) {
+                        Some(slot) => SettingsHit::FontPickerRow(slot),
+                        None => SettingsHit::FontSearchField,
+                    },
                     SettingsDropdown::BackgroundFit => SettingsHit::FitOption(index),
                     SettingsDropdown::BackgroundAlignment => SettingsHit::AlignOption(index),
                     SettingsDropdown::Language => SettingsHit::Language(LANGUAGE_OPTIONS[index]),
@@ -1434,8 +1485,11 @@ pub(super) struct SettingsView {
     pub(super) font_notice: Option<String>,
     /// 字体目录的「显示全部」临时过滤是否开启。
     pub(super) font_show_all: bool,
-    /// 字体目录搜索串；下拉展开且非空时顶替触发器上显示的字体名。
+    /// 字体目录搜索串；长在弹层顶部那个搜索框里。
     pub(super) font_query: String,
+    /// 搜索框的光标与选区。下沉到 [`super::ui::text_field`] 的同一套模型，
+    /// 新加的输入框直接继承，不必再实现一遍。
+    pub(super) font_query_cursor: text_field::TextCursor,
     /// 非等宽族的小写名集合；下拉行据此追加比例字体警告。
     pub(super) font_proportional: std::collections::HashSet<String>,
     /// Persistent soft-deleted destinations. Rows provide a discoverable
@@ -1609,7 +1663,10 @@ fn dropdown_selected_index(view: &SettingsView, dropdown: SettingsDropdown) -> O
         SettingsDropdown::Shell => {
             view.shells.iter().position(|(id, _, _)| view.shell_id.as_deref() == Some(id.as_str()))
         },
-        SettingsDropdown::Font => view.fonts.iter().position(|family| family == &view.font_family),
+        // 加一：弹层第 0 行是搜索框，候选整体下移一行。
+        SettingsDropdown::Font => {
+            view.fonts.iter().position(|family| family == &view.font_family).map(|slot| slot + 1)
+        },
         SettingsDropdown::BackgroundFit => {
             BACKGROUND_FIT_OPTIONS.iter().position(|fit| *fit == view.background_image_fit)
         },
@@ -1635,7 +1692,7 @@ fn dropdown_selected_index(view: &SettingsView, dropdown: SettingsDropdown) -> O
 fn dropdown_hover_index(hover: SettingsHit, dropdown: SettingsDropdown) -> Option<usize> {
     match (dropdown, hover) {
         (SettingsDropdown::Shell, SettingsHit::ShellPickerRow(index)) => Some(index),
-        (SettingsDropdown::Font, SettingsHit::FontPickerRow(index)) => Some(index),
+        (SettingsDropdown::Font, SettingsHit::FontPickerRow(index)) => Some(index + 1),
         (SettingsDropdown::BackgroundFit, SettingsHit::FitOption(index)) => Some(index),
         (SettingsDropdown::BackgroundAlignment, SettingsHit::AlignOption(index)) => Some(index),
         (SettingsDropdown::Language, SettingsHit::Language(preference)) => {
@@ -2213,11 +2270,7 @@ pub(super) fn push_quads(
                 view.hover == SettingsHit::TabRevealDropdown,
                 view.dropdown == Some(SettingsDropdown::TabReveal),
             );
-            row_hover(
-                quads,
-                geometry.panel_resize,
-                view.hover == SettingsHit::PanelResizeToggle,
-            );
+            row_hover(quads, geometry.panel_resize, view.hover == SettingsHit::PanelResizeToggle);
             toggle(quads, &mut staged, geometry.panel_resize, view.panel_resize);
             group_frame(quads, geometry.cjk_bold, 1);
             row_hover(quads, geometry.cjk_bold, view.hover == SettingsHit::CjkBoldToggle);
@@ -2513,6 +2566,23 @@ pub(super) fn push_popup_quads(
     let selected = dropdown_selected_index(view, dropdown);
     let hover = dropdown_hover_index(view.hover, dropdown);
     widgets::push_combobox_popup(quads, popup, count, selected, hover, scale, &sk);
+    // 字体弹层第 0 行是一个正经输入框：下沉底 + 光标/选区。它不是选项，所以
+    // 不吃 hover 高亮，走 `push_input` 而不是 popup 行的配方。
+    if matches!(dropdown, SettingsDropdown::Font) {
+        let field = widgets::popup_row_rect(popup, 0, scale);
+        surface::push_input(quads, field, scale, &sk, true);
+        text_field::push_cursor(
+            quads,
+            field.1,
+            field.3,
+            field.0 + s(12.0),
+            &view.font_query,
+            &view.font_query_cursor,
+            size.cell_width(),
+            scale,
+            &sk,
+        );
+    }
     if let Some(index) = selected {
         let (rx, ry, rw, rh) = widgets::popup_row_rect(popup, index, scale);
         icons::push_check(
@@ -2592,22 +2662,39 @@ pub(super) fn draw_popup_text(
                 text_x = rx + s(40.0);
                 if program.is_empty() { name.clone() } else { format!("{name}  ·  {program}") }
             },
-            SettingsDropdown::Font => match view.fonts.get(index) {
-                // 比例字体在固定终端网格下可能重叠或截断：标出来，但不拦着
-                // 用户选——这是知情选择，不是错误。
-                Some(family) if view.font_proportional.contains(&family.to_lowercase()) => {
-                    format!("{family}   {}", language.pick("· 非等宽", "· not monospaced"))
-                },
-                Some(family) => family.clone(),
-                // 倒数第二行是过滤切换，最后一行是导入。
-                None if index == view.fonts.len() => {
-                    if view.font_show_all {
-                        language.pick("◉  显示全部字体", "(*) Showing all fonts").to_owned()
+            SettingsDropdown::Font => {
+                // 第 0 行是搜索框：它的底与光标在 quads pass 里画，这里只
+                // 落查询串本身（空着时落提示语）。
+                let Some(slot) = font_popup_slot(index) else {
+                    let showing = !view.font_query.is_empty();
+                    let text = if showing {
+                        view.font_query.clone()
                     } else {
-                        language.pick("○  仅等宽字体", "( ) Monospaced only").to_owned()
-                    }
-                },
-                None => language.pick("＋  导入字体…", "+  Import font...").to_owned(),
+                        language
+                            .pick("搜索字体…（直接打字）", "Search fonts… (just type)")
+                            .to_owned()
+                    };
+                    let ink = if showing { sk.ink } else { sk.ink_faint };
+                    r.draw_chrome_text(size, text_x, ty, ink, &text, gc);
+                    continue;
+                };
+                match view.fonts.get(slot) {
+                    // 比例字体在固定终端网格下可能重叠或截断：标出来，但不拦着
+                    // 用户选——这是知情选择，不是错误。
+                    Some(family) if view.font_proportional.contains(&family.to_lowercase()) => {
+                        format!("{family}   {}", language.pick("· 非等宽", "· not monospaced"))
+                    },
+                    Some(family) => family.clone(),
+                    // 倒数第二行是过滤切换，最后一行是导入。
+                    None if slot == view.fonts.len() => {
+                        if view.font_show_all {
+                            language.pick("◉  显示全部字体", "(*) Showing all fonts").to_owned()
+                        } else {
+                            language.pick("○  仅等宽字体", "( ) Monospaced only").to_owned()
+                        }
+                    },
+                    None => language.pick("＋  导入字体…", "+  Import font...").to_owned(),
+                }
             },
             SettingsDropdown::BackgroundFit => {
                 background_image_fit_label(BACKGROUND_FIT_OPTIONS[index], language).to_owned()
@@ -2629,8 +2716,8 @@ pub(super) fn draw_popup_text(
             // 上方特判提前返回；此臂只为 match 完备。
             SettingsDropdown::BackgroundColor => continue,
         };
-        let import_row =
-            matches!(dropdown, SettingsDropdown::Font) && view.fonts.get(index).is_none();
+        let import_row = matches!(dropdown, SettingsDropdown::Font)
+            && font_popup_slot(index).is_some_and(|slot| view.fonts.get(slot).is_none());
         let color = if selected == Some(index) || import_row { sk.accent } else { sk.ink };
         let max_chars =
             (((rx + rw - s(28.0)) - text_x).max(cell_w) / cell_w).floor().max(1.0) as usize;
@@ -3304,12 +3391,10 @@ pub(super) fn draw_text(
                 }
             }
             if visible(geometry.font.1, geometry.font.3) {
-                // 搜索期间触发器顶替显示查询串——否则用户看不见自己在搜
-                // 什么。加载失败的告警优先于两者。
-                let searching = format!("\u{1f50d} {}", view.font_query);
+                // 查询串现在长在弹层顶部的搜索框里，触发器只管报当前字体。
+                // 加载失败的告警优先。
                 let font_value = match view.font_notice.as_deref() {
                     Some(notice) => notice,
-                    None if !view.font_query.is_empty() => &searching,
                     None => &view.font_family,
                 };
                 row_label(
@@ -3855,8 +3940,21 @@ pub(super) fn draw_text(
 #[cfg(test)]
 mod tests {
     use super::{
-        SHOW_WEBDAV_SYNC_SETTINGS, TabRevealMotion, advanced_content_end, opacity_from_pointer,
+        SHOW_WEBDAV_SYNC_SETTINGS, TabRevealMotion, advanced_content_end, font_popup_row_count,
+        font_popup_slot, opacity_from_pointer,
     };
+
+    #[test]
+    fn the_font_popup_reserves_its_first_row_for_the_search_field() {
+        // 搜索框占掉第 0 行，选项整体下移一行。用「多算一行」而不是另开一套
+        // 几何：弹层的定位、上下翻转与裁剪都还归 combobox_popup_rect 管。
+        assert_eq!(font_popup_row_count(0), 1, "一个字体都没有时也要有搜索框");
+        assert_eq!(font_popup_row_count(7), 8);
+
+        assert_eq!(font_popup_slot(0), None, "第 0 行是搜索框，不是选项");
+        assert_eq!(font_popup_slot(1), Some(0));
+        assert_eq!(font_popup_slot(4), Some(3));
+    }
 
     #[test]
     fn slider_pointer_maps_to_clamped_fraction() {

--- a/nebula_app/src/font_install.rs
+++ b/nebula_app/src/font_install.rs
@@ -4,6 +4,88 @@ use std::path::{Path, PathBuf};
 use sha2::{Digest, Sha256};
 
 pub const REQUIRED_FONT_FAMILY: &str = "Maple Mono Normal NF CN";
+
+/// 一个系统已安装字体族，连同平台给出的等宽判定。
+///
+/// 平台枚举本身留在这个类型之外：目录装配只吃普通字符串与布尔，因此可以
+/// 在任何平台上被测试。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemFontFamily {
+    pub name: String,
+    pub monospaced: bool,
+}
+
+/// 一个字体族在**字体目录**中的来源。同名冲突时系统记录优先。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FontSource {
+    System,
+    Imported,
+}
+
+/// 字体目录中的一项。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FontCatalogEntry {
+    pub name: String,
+    /// 非等宽族在界面上要给出比例字体警告，但仍可选择。
+    pub monospaced: bool,
+    pub source: FontSource,
+}
+
+/// 由系统字体族、Nebula 导入字体族、过滤开关与查询串装配**字体目录**。
+///
+/// - 同名（忽略大小写）合并为一项，系统记录优先。
+/// - 默认只列等宽族；`show_all` 临时显示全部。导入字体没有系统那样的等宽
+///   元数据，视作可用，默认视图不隐藏它们。
+/// - 搜索匹配的是列表上显示的那个名字，不维护跨语言别名。
+/// - `current` 是当前生效字体：即使不满足过滤或搜索条件也保留，否则用户
+///   会以为自己的选择丢了。
+pub fn font_catalog(
+    system: &[SystemFontFamily],
+    imported: &[String],
+    show_all: bool,
+    query: &str,
+    current: &str,
+) -> Vec<FontCatalogEntry> {
+    let mut entries: Vec<FontCatalogEntry> = Vec::with_capacity(system.len() + imported.len());
+    let mut seen: Vec<String> = Vec::with_capacity(system.len() + imported.len());
+    let key = |name: &str| name.to_lowercase();
+
+    for family in system {
+        let k = key(&family.name);
+        if seen.contains(&k) {
+            continue;
+        }
+        seen.push(k);
+        entries.push(FontCatalogEntry {
+            name: family.name.clone(),
+            monospaced: family.monospaced,
+            source: FontSource::System,
+        });
+    }
+    for name in imported {
+        let k = key(name);
+        if seen.contains(&k) {
+            continue;
+        }
+        seen.push(k);
+        entries.push(FontCatalogEntry {
+            name: name.clone(),
+            monospaced: true,
+            source: FontSource::Imported,
+        });
+    }
+
+    let needle = query.trim().to_lowercase();
+    let current_key = key(current);
+    entries.retain(|entry| {
+        let is_current = key(&entry.name) == current_key;
+        let passes_filter = show_all || entry.monospaced;
+        let passes_query = needle.is_empty() || entry.name.to_lowercase().contains(&needle);
+        is_current || (passes_filter && passes_query)
+    });
+    entries.sort_by_key(|entry| entry.name.to_lowercase());
+    entries
+}
 pub const REQUIRED_FONT_FILE: &str = "MapleMonoNormal-NF-CN-Regular.ttf";
 
 #[cfg(windows)]
@@ -98,6 +180,74 @@ pub fn bundled_font_directory() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sys(name: &str, monospaced: bool) -> SystemFontFamily {
+        SystemFontFamily { name: name.to_owned(), monospaced }
+    }
+
+    fn names(entries: &[FontCatalogEntry]) -> Vec<&str> {
+        entries.iter().map(|entry| entry.name.as_str()).collect()
+    }
+
+    #[test]
+    fn the_default_view_lists_only_monospaced_families() {
+        let system = [sys("Consolas", true), sys("Arial", false), sys("Cascadia Mono", true)];
+        let catalog = font_catalog(&system, &[], false, "", "Consolas");
+        assert_eq!(names(&catalog), ["Cascadia Mono", "Consolas"]);
+    }
+
+    #[test]
+    fn show_all_reveals_proportional_families_and_flags_them() {
+        let system = [sys("Consolas", true), sys("Arial", false)];
+        let catalog = font_catalog(&system, &[], true, "", "Consolas");
+        assert_eq!(names(&catalog), ["Arial", "Consolas"]);
+        let arial = catalog.iter().find(|entry| entry.name == "Arial").unwrap();
+        assert!(!arial.monospaced, "比例字体要能被标记出来，界面才谈得上给兼容性警告");
+    }
+
+    #[test]
+    fn a_system_family_absorbs_the_imported_one_of_the_same_name() {
+        // 用户可能把系统里已有的字体又导入了一份；目录里只该出现一个条目，
+        // 且以系统记录为准。
+        let system = [sys("Consolas", true)];
+        let imported = ["consolas".to_owned(), "Maple Mono".to_owned()];
+        let catalog = font_catalog(&system, &imported, false, "", "Consolas");
+        assert_eq!(names(&catalog), ["Consolas", "Maple Mono"]);
+        let consolas = catalog.iter().find(|entry| entry.name == "Consolas").unwrap();
+        assert_eq!(consolas.source, FontSource::System);
+    }
+
+    #[test]
+    fn imported_families_are_assumed_usable_in_the_default_view() {
+        // 导入字体是用户特意装进来的终端字体，没有系统那样的等宽元数据，
+        // 默认视图不能把它们藏起来。
+        let imported = ["Maple Mono".to_owned()];
+        let catalog = font_catalog(&[], &imported, false, "", "Maple Mono");
+        assert_eq!(names(&catalog), ["Maple Mono"]);
+        assert_eq!(catalog[0].source, FontSource::Imported);
+    }
+
+    #[test]
+    fn search_matches_the_displayed_name_case_insensitively() {
+        let system = [sys("Consolas", true), sys("Cascadia Mono", true), sys("Courier New", true)];
+        // 当前字体取列表外的值，否则它会被「当前项始终保留」的规则固定住，
+        // 这条测试就测不到纯粹的搜索结果了。
+        let current = "Maple Mono";
+        assert_eq!(names(&font_catalog(&system, &[], false, "cas", current)), ["Cascadia Mono"]);
+        assert_eq!(names(&font_catalog(&system, &[], false, "COURIER", current)), ["Courier New"]);
+        assert!(font_catalog(&system, &[], false, "没有这个字体", current).is_empty());
+    }
+
+    #[test]
+    fn the_current_font_stays_visible_even_when_it_would_be_filtered_out() {
+        // 当前生效字体从列表里消失，会让用户以为自己的选择丢了。
+        let system = [sys("Arial", false), sys("Consolas", true)];
+        let catalog = font_catalog(&system, &[], false, "", "Arial");
+        assert!(names(&catalog).contains(&"Arial"), "比例字体正在使用时不得被默认过滤藏掉");
+
+        let searched = font_catalog(&system, &[], false, "conso", "Arial");
+        assert!(names(&searched).contains(&"Arial"), "搜索不命中当前字体时也要保留它");
+    }
 
     #[test]
     fn packaged_font_directory_is_next_to_the_executable() {

--- a/nebula_app/src/input/chrome.rs
+++ b/nebula_app/src/input/chrome.rs
@@ -902,6 +902,15 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                         self.ctx.mark_dirty();
                         return;
                     },
+                    crate::display::SettingsHit::FontSearchField => {
+                        // 点搜索框是定位光标，不是关掉弹层——它是这次展开里
+                        // 唯一还接受输入的东西。
+                        let (text_x, cell_w) = self.ctx.display().font_search_text_origin();
+                        let extend = self.ctx.modifiers().state().shift_key();
+                        self.ctx.display().font_query_place(x - text_x, cell_w, extend);
+                        self.ctx.mark_dirty();
+                        return;
+                    },
                     crate::display::SettingsHit::FontPickerRow(index) => {
                         let base_font = self.ctx.config().font.clone();
                         self.ctx.display().set_terminal_font_by_index(index, &base_font);
@@ -1282,6 +1291,7 @@ fn settings_dropdown_keeps_open(hit: crate::display::SettingsHit) -> bool {
             | Hit::ShellPickerRow(_)
             | Hit::FontCycle
             | Hit::FontPickerRow(_)
+            | Hit::FontSearchField
             | Hit::BackgroundImageFit
             | Hit::FitOption(_)
             | Hit::BackgroundImageAlignment

--- a/nebula_app/src/input/keyboard.rs
+++ b/nebula_app/src/input/keyboard.rs
@@ -129,25 +129,56 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             return;
         }
 
-        // 字体目录展开时键盘归搜索：系统字体动辄几百个，没有过滤就只能
-        // 靠滚。Esc 关闭，退格删字符，其余可打印字符追加。
+        // 字体目录展开时键盘归弹层顶部的搜索框：系统字体动辄几百个，没有
+        // 过滤就只能靠滚。搜索框是正经输入框，光标与选区走组件层，和其它
+        // 字段同一套行为。
         if self.ctx.display().nebula_settings_dropdown
             == Some(crate::display::SettingsDropdown::Font)
         {
+            let ctrl = mods.control_key();
+            let shift = mods.shift_key();
             match &key.logical_key {
                 Key::Named(NamedKey::Escape) => {
                     self.ctx.display().close_settings_dropdown();
                 },
                 Key::Named(NamedKey::Backspace) => {
-                    self.ctx.display().font_query_backspace();
+                    self.ctx.display().font_query_edit(None);
                 },
-                Key::Named(NamedKey::Space) => {
-                    self.ctx.display().font_query_push(' ');
+                Key::Named(NamedKey::Delete) => {
+                    self.ctx.display().font_query_delete_forward();
                 },
-                Key::Character(text) if !mods.control_key() => {
-                    for ch in text.chars() {
-                        self.ctx.display().font_query_push(ch);
-                    }
+                Key::Named(NamedKey::ArrowLeft) => {
+                    self.ctx.display().font_query_move(false, shift);
+                },
+                Key::Named(NamedKey::ArrowRight) => {
+                    self.ctx.display().font_query_move(true, shift);
+                },
+                Key::Named(NamedKey::Home) => {
+                    self.ctx.display().font_query_jump(false, shift);
+                },
+                Key::Named(NamedKey::End) => {
+                    self.ctx.display().font_query_jump(true, shift);
+                },
+                Key::Named(NamedKey::Space) if !ctrl => {
+                    self.ctx.display().font_query_edit(Some(" "));
+                },
+                Key::Character(text) if ctrl => match text.as_str() {
+                    "a" | "A" => self.ctx.display().font_query_select_all(),
+                    "c" | "C" => {
+                        if let Some(selected) = self.ctx.display().font_query_selected_text() {
+                            self.ctx.clipboard_mut().store(ClipboardType::Clipboard, selected);
+                        }
+                    },
+                    "v" | "V" => {
+                        let pasted = self.ctx.clipboard_mut().load(ClipboardType::Clipboard);
+                        if !pasted.is_empty() {
+                            self.ctx.display().font_query_edit(Some(&pasted));
+                        }
+                    },
+                    _ => {},
+                },
+                Key::Character(text) => {
+                    self.ctx.display().font_query_edit(Some(text.as_str()));
                 },
                 _ => {},
             }

--- a/nebula_app/src/input/keyboard.rs
+++ b/nebula_app/src/input/keyboard.rs
@@ -129,6 +129,32 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             return;
         }
 
+        // 字体目录展开时键盘归搜索：系统字体动辄几百个，没有过滤就只能
+        // 靠滚。Esc 关闭，退格删字符，其余可打印字符追加。
+        if self.ctx.display().nebula_settings_dropdown
+            == Some(crate::display::SettingsDropdown::Font)
+        {
+            match &key.logical_key {
+                Key::Named(NamedKey::Escape) => {
+                    self.ctx.display().close_settings_dropdown();
+                },
+                Key::Named(NamedKey::Backspace) => {
+                    self.ctx.display().font_query_backspace();
+                },
+                Key::Named(NamedKey::Space) => {
+                    self.ctx.display().font_query_push(' ');
+                },
+                Key::Character(text) if !mods.control_key() => {
+                    for ch in text.chars() {
+                        self.ctx.display().font_query_push(ch);
+                    }
+                },
+                _ => {},
+            }
+            self.ctx.mark_dirty();
+            return;
+        }
+
         // An expanded settings dropdown is a transient picker. Esc only
         // dismisses; any other key dismisses and then follows its normal path.
         if self.ctx.display().nebula_settings_dropdown.is_some() {

--- a/nebula_app/src/input/mouse.rs
+++ b/nebula_app/src/input/mouse.rs
@@ -342,7 +342,9 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 self.ctx.window().set_mouse_cursor(CursorIcon::Pointer);
                 return;
             },
-            crate::display::SettingsHit::SyncInput(_) => {
+            crate::display::SettingsHit::SyncInput(_)
+            // 搜索框是文本字段，光标要变 I 形——和其它输入框一致。
+            | crate::display::SettingsHit::FontSearchField => {
                 self.ctx.window().set_mouse_cursor(CursorIcon::Text);
                 return;
             },

--- a/nebula_app/src/renderer/text/font_rasterizer.rs
+++ b/nebula_app/src/renderer/text/font_rasterizer.rs
@@ -136,6 +136,30 @@ impl Rasterizer {
         Ok(key)
     }
 
+    /// 枚举系统已安装字体族，并带上 DirectWrite 的权威等宽判定。
+    ///
+    /// 只在**字体目录**首次展开时调用：`FontCollection::system()` 加上逐族
+    /// 取首字体问 `IsMonospacedFont` 在装了几百个字体的机器上是实打实的
+    /// 开销，放在启动路径上会拖慢每一次冷启。
+    pub(crate) fn system_font_families(&self) -> Vec<crate::font_install::SystemFontFamily> {
+        let collection = FontCollection::system();
+        let mut families = collection
+            .families_iter()
+            .filter_map(|family| {
+                let name = family.family_name().ok()?;
+                // 取该族的首个字体问等宽：族内字重不同但等宽属性一致。
+                // 拿不到就按非等宽处理——宁可让它落进「显示全部」，也不要
+                // 把一个比例字体混进默认的等宽视图。
+                let monospaced =
+                    family.font(0).ok().and_then(|font| font.is_monospace()).unwrap_or(false);
+                Some(crate::font_install::SystemFontFamily { name, monospaced })
+            })
+            .collect::<Vec<_>>();
+        families.sort_by_key(|family| family.name.to_lowercase());
+        families.dedup_by(|left, right| left.name.eq_ignore_ascii_case(&right.name));
+        families
+    }
+
     pub(crate) fn private_font_families(&self) -> Vec<String> {
         let mut families = self
             .private_collection

--- a/nebula_app/src/renderer/text/glyph_cache.rs
+++ b/nebula_app/src/renderer/text/glyph_cache.rs
@@ -110,6 +110,11 @@ impl GlyphCache {
     }
 
     #[cfg(windows)]
+    pub fn system_font_families(&self) -> Vec<crate::font_install::SystemFontFamily> {
+        self.rasterizer.system_font_families()
+    }
+
+    #[cfg(windows)]
     pub fn add_private_font(
         &mut self,
         path: &std::path::Path,
@@ -120,6 +125,14 @@ impl GlyphCache {
     #[cfg(windows)]
     pub fn refresh_private_fonts(&mut self) -> Vec<String> {
         self.rasterizer.refresh_private_fonts()
+    }
+
+    /// 在不改变已配置终端字体的前提下，试着加载一个字体族。
+    ///
+    /// 字体目录纳入系统字体后，目录里的条目不再个个都是「已经成功加载过」
+    /// 的——任意系统族都可能加载失败。选择因此必须先过这一关再提交。
+    pub fn family_loads(&mut self, family: &str, size: Size) -> bool {
+        Self::font_family_available(&mut self.rasterizer, family, size)
     }
 
     /// Check a system font family without changing the configured terminal font.


### PR DESCRIPTION
### 功能

把 Windows 已安装字体纳入**字体目录**，让用户不必先手工导入就能选择常用字体，并让字体切换变成事务性操作。

- 扩展现有字体选择器而非另起一套：系统字体族与导入字体族合并去重，默认只显示等宽家族，可临时显示全部，按显示名搜索
- 等宽判定使用平台提供的权威接口（DirectWrite 家族枚举），不用字形宽度测量启发式
- 系统枚举惰性执行于首次展开字体列表，不放在应用启动路径上
- **事务性应用**：任意系统字体族都可能加载失败，先验证再持久化，失败回滚到当前字体——这是本项必须自带的安全网（上游目录封闭且预验证的顺序假设被打破）

### 附带改进

- 字体搜索从触发器上的无光标键入串，改为弹层顶部的正经搜索框（弹层第 0 行），拿到点击定位、拖选、Shift+方向键、Home/End、Delete、Ctrl+A/C/V —— 与 0.9 下沉的 `ui::text_field` 光标模型对齐
- 非等宽字体的行标记 `· 非等宽`，并在启动回退时给出字体回退提示

### 验证

- 分支 `pr/font-catalog`，HEAD `2d4efdf`，基于 `31fc791`（batch-0.9-baseline）
- `cargo test -p nebula --bin nebula` 通过（含新增测试），workspace 全量通过；`cargo check --workspace --release` 0 错误
- 差异边界：产品源码 + 测试，无本地工作流文档、无占位、无构建产物
- 上游等价性：基线检查确认上游无等价的系统字体目录

### 维护者承诺

按 ADR-0001（批次贡献模型）：本分支与本批次其他 PR 互不包含对方提交。**任一前项合并后，贡献方会立即把本分支重基到最新上游并解决机械冲突**——冲突成本由贡献方而非维护者承担。
