### PR TITLE
feat: compact appearance density preset

### DIFF
--- a/nebula_app/src/display/chrome.rs
+++ b/nebula_app/src/display/chrome.rs
@@ -467,7 +467,8 @@ pub(super) fn chrome_tab_layout(
     // 用户拖过 HOSTS 分界（设置开启拖拽调节）后，停靠区高度以覆盖值为准，
     // 钳在「只剩标题」与「至少给标签区留一行」之间；没拖过走弹性规则。
     let dock_cap = if model.hosts_band > 0.0 {
-        (model.hosts_band * scale_factor).clamp(dock_fixed, (content_h - pitch - gap).max(dock_fixed))
+        (model.hosts_band * scale_factor)
+            .clamp(dock_fixed, (content_h - pitch - gap).max(dock_fixed))
     } else {
         (content_h - rows_h(tabs_want, pitch) - gap).max(content_h * DOCK_MIN_SHARE).min(content_h)
     };
@@ -2253,6 +2254,7 @@ pub(super) fn draw_chrome(d: &mut Display) {
         &mut d.glyph_cache,
         &size,
         d.window.scale_factor as f32,
+        d.nebula_density,
     );
 
     // Palette's full-color shell icons (textured quads) staged after all chrome
@@ -2406,7 +2408,6 @@ mod sidebar_dock_tests {
         assert!(dragged.hosts[0].3 > 0.0);
         assert!(dragged.hosts[0].1 > dragged.hosts_header.1);
     }
-
 
     #[test]
     fn a_dragged_sidebar_width_widens_the_panel_one_to_one() {

--- a/nebula_app/src/display/chrome.rs
+++ b/nebula_app/src/display/chrome.rs
@@ -2241,6 +2241,7 @@ pub(super) fn draw_chrome(d: &mut Display) {
         &mut palette_quads,
         &size,
         d.window.scale_factor as f32,
+        d.nebula_density,
     );
     d.renderer.draw_ui(&size, &palette_quads);
 

--- a/nebula_app/src/display/chrome.rs
+++ b/nebula_app/src/display/chrome.rs
@@ -2139,6 +2139,7 @@ pub(super) fn draw_chrome(d: &mut Display) {
                         view.area,
                         view.scroll,
                         view.hidden_hosts.len(),
+                        view.density,
                     ) {
                         d.renderer.draw_background_image(
                             &size,

--- a/nebula_app/src/display/command_palette.rs
+++ b/nebula_app/src/display/command_palette.rs
@@ -954,12 +954,11 @@ impl CommandPalette {
             _ => return,
         };
         let rows = std::mem::take(&mut self.filtered);
-        let (mut head, tail): (Vec<_>, Vec<_>) = rows.into_iter().partition(|candidate| {
-            match candidate {
+        let (mut head, tail): (Vec<_>, Vec<_>) =
+            rows.into_iter().partition(|candidate| match candidate {
                 PaletteCandidate::AiSession(index) => self.ai_sessions[*index].source == lead,
                 _ => true,
-            }
-        });
+            });
         head.extend(tail);
         self.filtered = head;
     }
@@ -1037,10 +1036,8 @@ impl CommandPalette {
         match self.mode {
             PaletteMode::AiSessions => self.group_ai_sessions_by_source(),
             PaletteMode::Commands => {
-                let groups: Vec<_> =
-                    self.filtered.iter().map(|c| self.command_group(*c)).collect();
-                let mut paired: Vec<_> =
-                    groups.into_iter().zip(self.filtered.drain(..)).collect();
+                let groups: Vec<_> = self.filtered.iter().map(|c| self.command_group(*c)).collect();
+                let mut paired: Vec<_> = groups.into_iter().zip(self.filtered.drain(..)).collect();
                 paired.sort_by_key(|(group, _)| *group);
                 self.filtered = paired.into_iter().map(|(_, candidate)| candidate).collect();
             },
@@ -1347,11 +1344,17 @@ impl PaletteLayout {
 /// doesn't jump as the match count changes while typing; pickers shrink to
 /// their content. Every palette mode uses the same search-input geometry,
 /// keeping rendering, hover and click hit-testing on one contract.
-pub fn palette_layout(model: &CommandPalette, win_w: f32, win_h: f32, scale: f32) -> PaletteLayout {
+pub fn palette_layout(
+    model: &CommandPalette,
+    win_w: f32,
+    win_h: f32,
+    scale: f32,
+    density: super::ui::tokens::Density,
+) -> PaletteLayout {
     let s = |v: f32| v * scale;
     let margin = s(8.0);
     let pad = s(12.0);
-    let row_h = s(super::ui::tokens::control::COMPACT_ROW);
+    let row_h = s(super::ui::tokens::control::dense_row(density));
     // 搜索框与结果行等高：输入仍然可发现，但不会压过真正的数据内容。
     let input_h = row_h;
     let cards = model.is_picker();
@@ -1373,7 +1376,11 @@ pub fn palette_layout(model: &CommandPalette, win_w: f32, win_h: f32, scale: f32
         let slots = visible.max(1);
         let mut rest = slots;
         if hero {
-            rel_groups.push((y, model.language.pick("推荐", "Recommended").to_owned(), String::new()));
+            rel_groups.push((
+                y,
+                model.language.pick("推荐", "Recommended").to_owned(),
+                String::new(),
+            ));
             y += header_h;
             rel_rows.push((y, hero_h));
             y += hero_h + s(10.0);
@@ -1448,8 +1455,7 @@ pub fn palette_layout(model: &CommandPalette, win_w: f32, win_h: f32, scale: f32
     let input = (px + pad, py + pad, pw - 2.0 * pad, input_h);
     let list_y = py + pad + input_h + s(8.0);
     let rows = rel_rows.into_iter().map(|(ry, rh)| (list_y + ry, rh)).collect();
-    let groups =
-        rel_groups.into_iter().map(|(gy, label, ctx)| (list_y + gy, label, ctx)).collect();
+    let groups = rel_groups.into_iter().map(|(gy, label, ctx)| (list_y + gy, label, ctx)).collect();
 
     let footer = cards.then_some((px, py + ph - footer_h, pw, footer_h));
 
@@ -1509,7 +1515,7 @@ pub(super) fn push_quads(
     let h = size.height();
     let s = |v: f32| v * scale;
     let sk = theme.skin();
-    let layout = palette_layout(model, w, h, scale);
+    let layout = palette_layout(model, w, h, scale, density);
     let (ix, iy, iw, ih) = layout.input;
 
     // 命令面板是 Popover：可 Esc、无后果、随手开关，所以**不画遮罩**。
@@ -1530,7 +1536,14 @@ pub(super) fn push_quads(
         1.0,
     );
 
-    quads.push(UiQuad::solid(ix, iy, iw, ih, s(super::ui::tokens::radius::CONTROL), sk.input));
+    quads.push(UiQuad::solid(
+        ix,
+        iy,
+        iw,
+        ih,
+        s(super::ui::tokens::radius::control(density)),
+        sk.input,
+    ));
     if model.query_all_selected() && !model.query.is_empty() {
         let cell_w = size.cell_width();
         let columns: usize = model.query.chars().map(|c| c.width().unwrap_or(0)).sum();
@@ -1624,7 +1637,7 @@ pub(super) fn push_quads(
         // 只花一次，而这个面板里真正需要它的是"当前选中"这一处。
         // 推荐卡也不再染色——它已经被"推荐"分区标题、更大的尺寸、双行布局
         // 和右侧 ↵ chip 标记了四次身份，第五次是浪费。
-        let corner = s(super::ui::tokens::radius::OVERLAY);
+        let corner = s(super::ui::tokens::radius::overlay(density));
         for (row, &(ry, rh)) in layout.rows.iter().enumerate() {
             let is_hero = hero && row == 0;
             if selected_row == Some(row) {
@@ -1717,9 +1730,9 @@ pub(super) fn push_quads(
         // 环 + 面板底，与「默认」徽标同宗——身份标注，不与选中态抢强调色。
         // 文字在 text pass 按同一几何画。
         if !entry.chip.is_empty() {
-            let chip_w =
-                entry.chip.chars().map(|c| c.width().unwrap_or(1)).sum::<usize>() as f32 * cell_w
-                    + s(12.0);
+            let chip_w = entry.chip.chars().map(|c| c.width().unwrap_or(1)).sum::<usize>() as f32
+                * cell_w
+                + s(12.0);
             let cx = ix + iw - s(GUTTER) - chip_w;
             let cy = ry + s(7.0);
             let ch = rh - s(14.0);
@@ -1787,6 +1800,7 @@ pub(super) fn push_quads(
 /// it for the post-text image pass (a textured quad can't be interleaved with
 /// glyph batches). Rows whose id has no brand asset draw the Nerd Font glyph
 /// here and contribute nothing to the returned list.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn draw_text(
     model: &CommandPalette,
     theme: &NebulaTheme,
@@ -1794,6 +1808,7 @@ pub(super) fn draw_text(
     gc: &mut GlyphCache,
     size: &SizeInfo,
     scale: f32,
+    density: super::ui::tokens::Density,
 ) -> Vec<(String, (f32, f32, f32, f32))> {
     let mut icon_draws = Vec::new();
     if !model.is_open() {
@@ -1804,7 +1819,7 @@ pub(super) fn draw_text(
     let h = size.height();
     let cell_w = size.cell_width();
     let cell_h = size.cell_height();
-    let layout = palette_layout(model, w, h, scale);
+    let layout = palette_layout(model, w, h, scale, density);
     let (ix, iy, iw, ih) = layout.input;
 
     // Inks from the theme skin: dark text on light panels, pale on dark.
@@ -1938,8 +1953,8 @@ pub(super) fn draw_text(
         // brand asset stage a full-color textured quad (drawn later); the rest
         // fall back to the Nerd Font glyph. Built-in action rows carry an empty
         // icon and keep the original left edge.
-        let has_color = !color_id.is_empty()
-            && crate::shell_detect::color_icon_png(&color_id).is_some();
+        let has_color =
+            !color_id.is_empty() && crate::shell_detect::color_icon_png(&color_id).is_some();
         let indent = if is_hero { s(34.0) } else { s(26.0) };
         let label_x = if has_color {
             // Square icon sized to the glyph ink, vertically centered on the
@@ -2428,7 +2443,13 @@ mod tests {
     #[test]
     fn search_input_and_result_rows_share_compact_height() {
         let palette = CommandPalette::new();
-        let layout = palette_layout(&palette, 1600.0, 900.0, 1.5);
+        let layout = palette_layout(
+            &palette,
+            1600.0,
+            900.0,
+            1.5,
+            crate::display::ui::tokens::Density::Standard,
+        );
         assert_eq!(layout.input.3, layout.row_h);
     }
 
@@ -2533,12 +2554,14 @@ mod tests {
             CommandGroup::Tabs,
             "开不在那里就不能挂在工作目录标题下"
         );
-        assert!(palette
-            .group_labels(palette.filtered.len())
-            .unwrap()
-            .into_iter()
-            .flatten()
-            .any(|(label, _)| label == "工作目录"));
+        assert!(
+            palette
+                .group_labels(palette.filtered.len())
+                .unwrap()
+                .into_iter()
+                .flatten()
+                .any(|(label, _)| label == "工作目录")
+        );
     }
 
     /// 开关类命令带勾选态，一次性动作不带。列表里同时有两类时，✓ 是唯一
@@ -2578,9 +2601,8 @@ mod tests {
         });
         assert!(palette.filtered.len() > MAX_ROWS * 2, "要够长才能翻页");
 
-        let group_at = |palette: &CommandPalette, index: usize| {
-            palette.command_group(palette.filtered[index])
-        };
+        let group_at =
+            |palette: &CommandPalette, index: usize| palette.command_group(palette.filtered[index]);
         let top_label = |palette: &CommandPalette| {
             palette.group_labels(MAX_ROWS).unwrap()[0].as_ref().map(|(l, _)| l.clone())
         };
@@ -2601,7 +2623,8 @@ mod tests {
         );
         // 窗口内其余各行只在换组时起表头。
         for (offset, label) in labels.iter().enumerate().skip(1) {
-            let changed = group_at(&palette, start + offset) != group_at(&palette, start + offset - 1);
+            let changed =
+                group_at(&palette, start + offset) != group_at(&palette, start + offset - 1);
             assert_eq!(label.is_some(), changed, "第 {offset} 行的表头判定与实际换组不符");
         }
     }
@@ -2656,12 +2679,18 @@ mod tests {
             "powershell",
         );
         palette.open_profiles();
-        let layout = palette_layout(&palette, 1600.0, 900.0, 1.0);
+        let layout = palette_layout(
+            &palette,
+            1600.0,
+            900.0,
+            1.0,
+            crate::display::ui::tokens::Density::Standard,
+        );
         assert_eq!(layout.rows.len(), 2);
         let (hero_y, hero_h) = layout.rows[0];
         let (row_y, row_h) = layout.rows[1];
         assert!(hero_h > row_h, "推荐大卡片必须比普通卡片高");
-        assert_eq!(layout.groups.len(), 2, "hero 版式仍是「推荐 / 所有选项」两条表头");        // 命中测试与逐行矩形一致；卡片之间的缝隙与分区标题不可点。
+        assert_eq!(layout.groups.len(), 2, "hero 版式仍是「推荐 / 所有选项」两条表头"); // 命中测试与逐行矩形一致；卡片之间的缝隙与分区标题不可点。
         let (px, ..) = layout.panel;
         assert_eq!(layout.row_at(px + 10.0, hero_y + hero_h / 2.0), Some(0));
         assert_eq!(layout.row_at(px + 10.0, row_y + row_h / 2.0), Some(1));
@@ -2673,7 +2702,13 @@ mod tests {
     fn command_layout_rows_stay_uniform() {
         let mut palette = CommandPalette::new();
         palette.open();
-        let layout = palette_layout(&palette, 1600.0, 900.0, 1.0);
+        let layout = palette_layout(
+            &palette,
+            1600.0,
+            900.0,
+            1.0,
+            crate::display::ui::tokens::Density::Standard,
+        );
         assert_eq!(layout.rows.len(), layout.max_rows.min(palette.filtered.len()));
         for pair in layout.rows.windows(2) {
             assert_eq!(pair[0].1, pair[1].1, "命令列表保持等高行");

--- a/nebula_app/src/display/command_palette.rs
+++ b/nebula_app/src/display/command_palette.rs
@@ -1500,6 +1500,7 @@ pub(super) fn push_quads(
     quads: &mut Vec<UiQuad>,
     size: &SizeInfo,
     scale: f32,
+    density: super::ui::tokens::Density,
 ) {
     if !model.is_open() {
         return;
@@ -1524,6 +1525,7 @@ pub(super) fn push_quads(
         (w, h),
         scale,
         &sk,
+        density,
         surface::Elevation::Popover,
         1.0,
     );

--- a/nebula_app/src/display/context_menu.rs
+++ b/nebula_app/src/display/context_menu.rs
@@ -504,6 +504,7 @@ pub(super) fn draw(display: &mut Display) {
         (size.width(), size.height()),
         scale,
         &sk,
+        display.nebula_density,
         surface::Elevation::Menu,
         progress,
     );

--- a/nebula_app/src/display/mod.rs
+++ b/nebula_app/src/display/mod.rs
@@ -2103,6 +2103,7 @@ impl Display {
             area,
             self.nebula_settings_section,
             self.nebula_hidden_hosts.len(),
+            self.nebula_density,
         );
         let next = (self.nebula_settings_scroll + delta).clamp(0.0, max);
         if (next - self.nebula_settings_scroll).abs() > f32::EPSILON {
@@ -3529,6 +3530,7 @@ impl Display {
             self.terminal_card_rect(),
             self.nebula_settings_scroll,
             target,
+            self.nebula_density,
         );
         self.nebula_settings_opacity_drag = Some((target, slider.0, slider.2));
         self.update_settings_opacity_drag(pointer_x);

--- a/nebula_app/src/display/mod.rs
+++ b/nebula_app/src/display/mod.rs
@@ -4046,6 +4046,7 @@ impl Display {
             size.width(),
             size.height(),
             self.window.scale_factor as f32,
+            self.nebula_density,
         )
     }
 
@@ -6771,6 +6772,7 @@ impl Display {
             self.ssh_connect_rect(),
             self.window.scale_factor as f32,
             self.nebula_language,
+            self.nebula_density,
             x,
             y,
         )
@@ -6835,6 +6837,7 @@ impl Display {
                     rect,
                     scale,
                     language,
+                    self.nebula_density,
                     backdrop,
                 );
                 self.renderer.draw_ui(&size, &quads);
@@ -6848,6 +6851,7 @@ impl Display {
                     &size,
                     rect,
                     scale,
+                    self.nebula_density,
                 );
             }
             // 门槛期内也要保持帧循环，否则永远到不了该显示的那一帧。

--- a/nebula_app/src/display/mod.rs
+++ b/nebula_app/src/display/mod.rs
@@ -134,6 +134,7 @@ pub(crate) fn caret_blink_on() -> bool {
 }
 pub(crate) use settings::SettingsOpacityTarget;
 pub use settings::{NebulaSettingsSection, SettingsDropdown, SettingsHit, settings_hit};
+pub(crate) use ui::tokens::Density;
 
 /// 按显示列宽贪心断行（确认框正文等 UI 段落用）：CJK 逐字可断，行首空
 /// 格吞掉；零宽字符跟随前一个字。不做拉丁连词回退——正文以中文为主，
@@ -1450,6 +1451,9 @@ pub struct Display {
     /// 捕获态实时回显：当前按住的修饰键前缀（"Ctrl+Shift+"）。松开清空。
     pub nebula_keymap_capture_preview: String,
     pub nebula_tab_reveal_motion: settings::TabRevealMotion,
+    /// 界面外观预设。紧凑只在既有阶梯上降一档，不引入新的视觉数值
+    /// （ADR-0002）；它不改变终端字体、单元格几何或 shell 输出。
+    pub nebula_density: ui::tokens::Density,
     pub nebula_font_family: String,
     nebula_font_families: Vec<String>,
     nebula_font_notice: Option<String>,
@@ -1968,6 +1972,7 @@ impl Display {
             nebula_keymap_capture: None,
             nebula_keymap_capture_preview: String::new(),
             nebula_tab_reveal_motion: settings_init.tab_reveal,
+            nebula_density: settings_init.density,
             nebula_font_family: settings_init.font_family,
             nebula_font_families,
             nebula_font_notice: None,
@@ -2992,6 +2997,7 @@ impl Display {
             panel_resize: self.nebula_panel_resize,
             cjk_bold_regular: self.nebula_cjk_bold_regular,
             tab_reveal: self.nebula_tab_reveal_motion,
+            density: self.nebula_density,
             preview_bg: self.preview_terminal_bg(),
             preview_fg: {
                 let bg = self.preview_terminal_bg();
@@ -3232,6 +3238,25 @@ impl Display {
         }
         self.nebula_settings_dropdown = None;
         self.pending_update.dirty = true;
+    }
+
+    /// 切换界面外观预设。密度只影响 Nebula 原生界面的留白、行高与圆角；
+    /// 终端字体、单元格几何与 shell 输出一概不受影响，但界面让出的空间会
+    /// 让终端行列数增加——那正是紧凑档的收益。
+    pub fn set_density_option(&mut self, index: usize) {
+        if let Some(density) = settings::DENSITY_OPTIONS.get(index).copied()
+            && density != self.nebula_density
+        {
+            self.nebula_density = density;
+            self.persist_nebula_settings();
+            // 与折叠侧栏同样的重排路径：界面尺寸变了，网格与 PTY 要跟上。
+            let size =
+                PhysicalSize::new(self.size_info.width() as u32, self.size_info.height() as u32);
+            self.pending_update.set_dimensions(size);
+        }
+        self.nebula_settings_dropdown = None;
+        self.pending_update.dirty = true;
+        self.window.request_redraw();
     }
 
     /// Returns true when the default cursor style changed (the caller then
@@ -4812,6 +4837,7 @@ impl Display {
             copy_on_select: self.nebula_copy_on_select,
             cjk_bold_regular: self.nebula_cjk_bold_regular,
             tab_reveal: self.nebula_tab_reveal_motion,
+            density: self.nebula_density,
             theme: self.nebula_theme_preference,
             follow_system_theme: self.nebula_follow_system_theme,
             pinned_hosts: self.nebula_pinned_hosts.clone(),
@@ -4909,6 +4935,7 @@ impl Display {
             self.reset_glyph_cache();
         }
         self.nebula_tab_reveal_motion = settings.tab_reveal;
+        self.nebula_density = settings.density;
         self.nebula_window_opacity = settings.opacity;
         self.nebula_background = if settings.follow_system_theme {
             Some(active_theme.palette().term_bg)
@@ -6340,6 +6367,7 @@ impl Display {
             (size.width(), size.height()),
             scale,
             &sk,
+            self.nebula_density,
             ui::surface::Elevation::Modal,
             1.0,
         );
@@ -6516,6 +6544,7 @@ impl Display {
             (size.width(), size.height()),
             scale,
             &sk,
+            self.nebula_density,
             ui::surface::Elevation::Menu,
             1.0,
         );
@@ -6606,6 +6635,7 @@ impl Display {
             (size.width(), size.height()),
             scale,
             &sk,
+            self.nebula_density,
             ui::surface::Elevation::Menu,
             1.0,
         );

--- a/nebula_app/src/display/settings.rs
+++ b/nebula_app/src/display/settings.rs
@@ -94,6 +94,7 @@ pub enum SettingsDropdown {
     Accept,
     CursorShape,
     TabReveal,
+    Density,
     /// 背景色：色板网格 + 16 进制输入的专用浮层（不是通用行列表）。
     BackgroundColor,
 }
@@ -143,6 +144,9 @@ pub(super) const ACCEPT_OPTIONS: [AcceptKey; 3] =
 pub(super) const TAB_REVEAL_OPTIONS: [TabRevealMotion; 2] =
     [TabRevealMotion::Slide, TabRevealMotion::Instant];
 
+pub(super) const DENSITY_OPTIONS: [super::ui::tokens::Density; 2] =
+    [super::ui::tokens::Density::Standard, super::ui::tokens::Density::Compact];
+
 /// Order mirrors the appearance page the user referenced.
 pub(super) const CURSOR_SHAPE_OPTIONS: [CursorShape; 4] =
     [CursorShape::Beam, CursorShape::Underline, CursorShape::Block, CursorShape::HollowBlock];
@@ -175,6 +179,31 @@ fn tab_reveal_label(motion: TabRevealMotion, language: UiLanguage) -> &'static s
     match motion {
         TabRevealMotion::Slide => language.pick("滑动", "Slide"),
         TabRevealMotion::Instant => language.pick("立即", "Instant"),
+    }
+}
+
+pub(super) fn density_label(
+    density: super::ui::tokens::Density,
+    language: UiLanguage,
+) -> &'static str {
+    match density {
+        super::ui::tokens::Density::Standard => language.pick("标准", "Standard"),
+        super::ui::tokens::Density::Compact => language.pick("紧凑", "Compact"),
+    }
+}
+
+pub(super) fn density_parse(value: &str) -> Option<super::ui::tokens::Density> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "standard" => Some(super::ui::tokens::Density::Standard),
+        "compact" => Some(super::ui::tokens::Density::Compact),
+        _ => None,
+    }
+}
+
+pub(super) fn density_settings_value(density: super::ui::tokens::Density) -> &'static str {
+    match density {
+        super::ui::tokens::Density::Standard => "standard",
+        super::ui::tokens::Density::Compact => "compact",
     }
 }
 
@@ -240,6 +269,8 @@ pub enum SettingsHit {
     CjkBoldToggle,
     TabRevealDropdown,
     TabRevealOption(usize),
+    DensityDropdown,
+    DensityOption(usize),
     /// Language combobox trigger (options resolve to [`SettingsHit::Language`]).
     LanguageDropdown,
     /// Expanded dropdown option rows for the cycle-style settings.
@@ -309,6 +340,8 @@ pub(super) struct NebulaRuntimeSettings {
     /// 默认开：小字号下雅黑 Bold fallback 与 Regular 混排发闷（任务 #4）。
     pub(super) cjk_bold_regular: bool,
     pub(super) tab_reveal: TabRevealMotion,
+    /// 界面外观预设：标准 / 紧凑。
+    pub(super) density: super::ui::tokens::Density,
     pub(super) fetch: bool,
     pub(super) powerline: bool,
     /// Window close keeps the PTYs alive in the resident process (detach /
@@ -381,6 +414,7 @@ pub(super) fn nebula_settings_load(config: &UiConfig) -> NebulaRuntimeSettings {
         copy_on_select: true,
         cjk_bold_regular: true,
         tab_reveal: TabRevealMotion::Slide,
+        density: super::ui::tokens::Density::Standard,
         // Off by default: the welcome screen pipes a whole script through the
         // fresh shell and repaints on resize — real startup-latency cost on
         // the critical path (user ruling: startup speed outranks the art).
@@ -467,6 +501,9 @@ pub(super) fn nebula_settings_load(config: &UiConfig) -> NebulaRuntimeSettings {
                 Some(("cjk_bold_regular", v)) => settings.cjk_bold_regular = parse_bool(v, true),
                 Some(("tab_reveal", v)) => {
                     settings.tab_reveal = TabRevealMotion::parse(v).unwrap_or_default();
+                },
+                Some(("density", v)) => {
+                    settings.density = density_parse(v).unwrap_or_default();
                 },
                 Some(("startup_directory", v)) => {
                     let path = std::path::PathBuf::from(v.trim());
@@ -681,7 +718,7 @@ pub(super) fn nebula_settings_write(settings: &NebulaRuntimeSettings) {
         path,
         format!(
             "language={}\ntheme={theme}\nfollow_system_theme={}\nghost={}\naccept={accept}\nshell={shell}\nstartup_directory={startup_directory}\nfont_family={}\nfont_size={font_size}\ncursor_shape={}\ncursor_blink={}\ncopy_on_select={}\ncjk_bold_regular={}
-tab_reveal={}\nfetch={}\npowerline={}\nkeep_session={}\nrestore_session={}\nblur={}\nopacity={:.2}\nbackground={background}\nbackground_image={background_image}\nbackground_image_opacity={:.2}\nbackground_image_fit={}\nbackground_image_alignment={}\nbackground_image_cover_chrome={}\npanel_resize={}\nsidebar_w={:.0}\ndrawer_w={:.0}\nhosts_band={:.0}\npinned_hosts={pinned_hosts}\nsaved_hosts={saved_hosts}\nhidden_hosts={hidden_hosts}\nquick_terminal_hotkey={quick_terminal_hotkey}\n{keybinds}",
+tab_reveal={}\ndensity={}\nfetch={}\npowerline={}\nkeep_session={}\nrestore_session={}\nblur={}\nopacity={:.2}\nbackground={background}\nbackground_image={background_image}\nbackground_image_opacity={:.2}\nbackground_image_fit={}\nbackground_image_alignment={}\nbackground_image_cover_chrome={}\npanel_resize={}\nsidebar_w={:.0}\ndrawer_w={:.0}\nhosts_band={:.0}\npinned_hosts={pinned_hosts}\nsaved_hosts={saved_hosts}\nhidden_hosts={hidden_hosts}\nquick_terminal_hotkey={quick_terminal_hotkey}\n{keybinds}",
             settings.language.as_str(),
             settings.follow_system_theme as u8,
             settings.ghost as u8,
@@ -691,6 +728,7 @@ tab_reveal={}\nfetch={}\npowerline={}\nkeep_session={}\nrestore_session={}\nblur
             settings.copy_on_select as u8,
             settings.cjk_bold_regular as u8,
             settings.tab_reveal.settings_value(),
+            density_settings_value(settings.density),
             settings.fetch as u8,
             settings.powerline as u8,
             settings.keep_session as u8,
@@ -738,6 +776,7 @@ struct SettingsGeometry {
     hidden_host_count: usize,
     /// Full-width "窗口透明度" row and its draggable track.
     language_row: (f32, f32, f32, f32),
+    density_row: (f32, f32, f32, f32),
     opacity_row: (f32, f32, f32, f32),
     opacity_slider: (f32, f32, f32, f32),
     /// 「窗口背景模糊」开关，紧贴透明度滑块——它只在透明时才看得出效果。
@@ -886,7 +925,8 @@ fn settings_geometry(
     // 光标组：形状下拉 + 闪烁开关。
     let cursor_y0 = color_y0 + 6.0 * ROW_H + GROUP_ADVANCE;
     let iface_y0 = cursor_y0 + 2.0 * ROW_H + GROUP_ADVANCE;
-    let opacity_y0 = iface_y0 + ROW_H;
+    let density_y0 = iface_y0 + ROW_H;
+    let opacity_y0 = density_y0 + ROW_H;
     // 模糊开关跟在透明度后面：它修饰的正是透明度透出来的那层东西，隔开就
     // 读不出这层因果了。
     let blur_y0 = opacity_y0 + ROW_H;
@@ -997,6 +1037,7 @@ fn settings_geometry(
         cursor_shape_row: (row_x, at(cursor_y0), row_w, row_h),
         cursor_blink_row: (row_x, at(cursor_y0 + ROW_H), row_w, row_h),
         language_row: (row_x, at(iface_y0), row_w, row_h),
+        density_row: (row_x, at(density_y0), row_w, row_h),
         opacity_row,
         opacity_slider,
         blur: (row_x, at(blur_y0), row_w, row_h),
@@ -1147,6 +1188,9 @@ fn dropdown_anchor(
         (Section::Appearance, SettingsDropdown::Language) => {
             Some((anchor(geometry.language_row), LANGUAGE_OPTIONS.len()))
         },
+        (Section::Appearance, SettingsDropdown::Density) => {
+            Some((anchor(geometry.density_row), DENSITY_OPTIONS.len()))
+        },
         (Section::Appearance, SettingsDropdown::CursorShape) => {
             Some((anchor(geometry.cursor_shape_row), CURSOR_SHAPE_OPTIONS.len()))
         },
@@ -1226,6 +1270,7 @@ pub fn settings_hit(
                     SettingsDropdown::Language => SettingsHit::Language(LANGUAGE_OPTIONS[index]),
                     SettingsDropdown::Accept => SettingsHit::AcceptOption(index),
                     SettingsDropdown::TabReveal => SettingsHit::TabRevealOption(index),
+                    SettingsDropdown::Density => SettingsHit::DensityOption(index),
                     SettingsDropdown::CursorShape => SettingsHit::CursorShapeOption(index),
                     // 背景色浮层在上方特判处理，走不到通用行列表。
                     SettingsDropdown::BackgroundColor => SettingsHit::Panel,
@@ -1290,6 +1335,9 @@ pub fn settings_hit(
                 }
                 if contains_rect(geometry.language_row, x, y) {
                     return SettingsHit::LanguageDropdown;
+                }
+                if contains_rect(geometry.density_row, x, y) {
+                    return SettingsHit::DensityDropdown;
                 }
                 if contains_rect(geometry.blur, x, y) {
                     return SettingsHit::BlurToggle;
@@ -1451,6 +1499,7 @@ pub(super) struct SettingsView {
     pub(super) panel_resize: bool,
     pub(super) cjk_bold_regular: bool,
     pub(super) tab_reveal: TabRevealMotion,
+    pub(super) density: super::ui::tokens::Density,
     /// Live-preview colors: the ACTUAL terminal background/foreground the
     /// grid would use right now (custom background wins over the theme).
     pub(super) preview_bg: Rgb,
@@ -1617,6 +1666,7 @@ fn dropdown_selected_index(view: &SettingsView, dropdown: SettingsDropdown) -> O
         SettingsDropdown::TabReveal => {
             TAB_REVEAL_OPTIONS.iter().position(|motion| *motion == view.tab_reveal)
         },
+        SettingsDropdown::Density => DENSITY_OPTIONS.iter().position(|d| *d == view.density),
         SettingsDropdown::CursorShape => {
             CURSOR_SHAPE_OPTIONS.iter().position(|shape| *shape == view.cursor_shape)
         },
@@ -1637,6 +1687,7 @@ fn dropdown_hover_index(hover: SettingsHit, dropdown: SettingsDropdown) -> Optio
         },
         (SettingsDropdown::Accept, SettingsHit::AcceptOption(index)) => Some(index),
         (SettingsDropdown::TabReveal, SettingsHit::TabRevealOption(index)) => Some(index),
+        (SettingsDropdown::Density, SettingsHit::DensityOption(index)) => Some(index),
         (SettingsDropdown::CursorShape, SettingsHit::CursorShapeOption(index)) => Some(index),
         _ => None,
     }
@@ -2093,7 +2144,8 @@ pub(super) fn push_quads(
             );
             toggle(quads, &mut staged, geometry.cursor_blink_row, view.cursor_blink);
 
-            // 界面组：语言（同一通用下拉组件）+ 终端不透明度 + 背景模糊。
+            // 界面组：语言（同一通用下拉组件）+ 界面外观预设 + 终端不透明度
+            // + 背景模糊。
             group_frame(quads, geometry.language_row, 3);
             row_hover(quads, geometry.language_row, view.hover == SettingsHit::LanguageDropdown);
             combobox(
@@ -2102,6 +2154,14 @@ pub(super) fn push_quads(
                 geometry.language_row,
                 view.hover == SettingsHit::LanguageDropdown,
                 view.dropdown == Some(SettingsDropdown::Language),
+            );
+            row_hover(quads, geometry.density_row, view.hover == SettingsHit::DensityDropdown);
+            combobox(
+                quads,
+                &mut staged,
+                geometry.density_row,
+                view.hover == SettingsHit::DensityDropdown,
+                view.dropdown == Some(SettingsDropdown::Density),
             );
             slider(
                 quads,
@@ -2506,7 +2566,7 @@ pub(super) fn push_popup_quads(
         widgets::combobox_popup_rect(anchor, count, scale, geometry.content_top, py + ph - s(6.0));
     let selected = dropdown_selected_index(view, dropdown);
     let hover = dropdown_hover_index(view.hover, dropdown);
-    widgets::push_combobox_popup(quads, popup, count, selected, hover, scale, &sk);
+    widgets::push_combobox_popup(quads, popup, count, selected, hover, scale, &sk, view.density);
     if let Some(index) = selected {
         let (rx, ry, rw, rh) = widgets::popup_row_rect(popup, index, scale);
         icons::push_check(
@@ -2604,6 +2664,7 @@ pub(super) fn draw_popup_text(
             SettingsDropdown::TabReveal => {
                 tab_reveal_label(TAB_REVEAL_OPTIONS[index], language).to_owned()
             },
+            SettingsDropdown::Density => density_label(DENSITY_OPTIONS[index], language).to_owned(),
             SettingsDropdown::CursorShape => {
                 cursor_shape_label(CURSOR_SHAPE_OPTIONS[index], language).to_owned()
             },
@@ -3161,6 +3222,24 @@ pub(super) fn draw_text(
                     gc,
                     geometry.language_row,
                     language_label(view.language_preference, language),
+                    sk.accent,
+                );
+            }
+            if visible(geometry.density_row.1, geometry.density_row.3) {
+                let (dr_x, dr_y, _, dr_h) = geometry.density_row;
+                r.draw_chrome_text(
+                    size,
+                    dr_x + s(16.0),
+                    dr_y + (dr_h - cell_h) / 2.0,
+                    sk.ink,
+                    language.pick("界面外观", "Appearance"),
+                    gc,
+                );
+                combobox_value(
+                    r,
+                    gc,
+                    geometry.density_row,
+                    density_label(view.density, language),
                     sk.accent,
                 );
             }

--- a/nebula_app/src/display/settings.rs
+++ b/nebula_app/src/display/settings.rs
@@ -843,8 +843,10 @@ pub(super) fn settings_max_scroll(
     area: (f32, f32, f32, f32),
     section: NebulaSettingsSection,
     hidden_host_count: usize,
+    density: super::ui::tokens::Density,
 ) -> f32 {
-    let geometry = settings_geometry(size_info, scale_factor, area, 0.0, hidden_host_count);
+    let geometry =
+        settings_geometry(size_info, scale_factor, area, 0.0, hidden_host_count, density);
     let (_, _, _, ph) = geometry.popup;
     let content_h = match section {
         NebulaSettingsSection::Appearance => geometry.appearance_h,
@@ -862,6 +864,7 @@ fn settings_geometry(
     area: (f32, f32, f32, f32),
     scroll: f32,
     hidden_host_count: usize,
+    density: super::ui::tokens::Density,
 ) -> SettingsGeometry {
     let s = |v: f32| v * scale_factor;
     let gear = chrome_settings_button_rect(size_info, scale_factor);
@@ -887,8 +890,13 @@ fn settings_geometry(
     // CONTIGUOUS — one hairline frame around the block, hairline separators
     // between rows — and a finished group leaves 32px before the next title,
     // so `74 = 32 (section gap) + 42 (hanging title)`.
-    const ROW_H: f32 = 44.0;
-    const GROUP_ADVANCE: f32 = 74.0;
+    // 行高与组间距按密度降档：紧凑用阶梯上既有的 COMPACT_ROW，组间距
+    // 随行高等量收窄，不引入新数值。
+    let row_advance = super::ui::tokens::control::settings_row(density);
+    #[allow(non_snake_case)]
+    let ROW_H: f32 = row_advance;
+    #[allow(non_snake_case)]
+    let GROUP_ADVANCE: f32 = 74.0 - (44.0 - row_advance);
     // 预览卡设计高度：两行示例文本 + 光标演示的呼吸空间。
     const PREVIEW_H: f32 = 150.0;
 
@@ -1086,8 +1094,9 @@ pub(crate) fn opacity_slider_rect(
     area: (f32, f32, f32, f32),
     scroll: f32,
     target: SettingsOpacityTarget,
+    density: super::ui::tokens::Density,
 ) -> (f32, f32, f32, f32) {
-    let geometry = settings_geometry(size_info, scale_factor, area, scroll, 0);
+    let geometry = settings_geometry(size_info, scale_factor, area, scroll, 0, density);
     match target {
         SettingsOpacityTarget::Terminal => geometry.opacity_slider,
         SettingsOpacityTarget::BackgroundImage => geometry.background_image_opacity_slider,
@@ -1107,8 +1116,9 @@ pub(super) fn appearance_preview_wallpaper_rects(
     area: (f32, f32, f32, f32),
     scroll: f32,
     hidden_hosts: usize,
+    density: super::ui::tokens::Density,
 ) -> Option<((f32, f32, f32, f32), (f32, f32, f32, f32))> {
-    let geometry = settings_geometry(size_info, scale_factor, area, scroll, hidden_hosts);
+    let geometry = settings_geometry(size_info, scale_factor, area, scroll, hidden_hosts, density);
     let (vx, vy, vw, vh) = geometry.preview;
     let (_, content_y, _, _) = geometry.content;
     let (_, py, _, ph) = geometry.popup;
@@ -1215,8 +1225,10 @@ pub fn settings_hit(
     shell_count: usize,
     font_count: usize,
     hidden_host_count: usize,
+    density: super::ui::tokens::Density,
 ) -> SettingsHit {
-    let geometry = settings_geometry(size_info, scale_factor, area, scroll, hidden_host_count);
+    let geometry =
+        settings_geometry(size_info, scale_factor, area, scroll, hidden_host_count, density);
     let s = |v: f32| v * scale_factor;
 
     if contains_rect(geometry.gear, x, y) {
@@ -1703,7 +1715,14 @@ pub(super) fn push_quads(
     let s = |v: f32| v * scale;
     let sk = view.theme.skin();
 
-    let geometry = settings_geometry(size, scale, view.area, view.scroll, view.hidden_hosts.len());
+    let geometry = settings_geometry(
+        size,
+        scale,
+        view.area,
+        view.scroll,
+        view.hidden_hosts.len(),
+        view.density,
+    );
     let (px, py, pw, ph) = geometry.popup;
     // Header band height: the title row sits above the content, and the header
     // separator + big title are all measured from here.
@@ -2458,7 +2477,14 @@ pub(super) fn push_popup_quads(
     let Some(dropdown) = view.dropdown else { return };
     let s = |v: f32| v * scale;
     let sk = view.theme.skin();
-    let geometry = settings_geometry(size, scale, view.area, view.scroll, view.hidden_hosts.len());
+    let geometry = settings_geometry(
+        size,
+        scale,
+        view.area,
+        view.scroll,
+        view.hidden_hosts.len(),
+        view.density,
+    );
     // 背景色专用浮层：色板网格 + hex 输入框（几何与 hit 同源）。
     if dropdown == SettingsDropdown::BackgroundColor {
         if view.section != NebulaSettingsSection::Appearance {
@@ -2596,7 +2622,14 @@ pub(super) fn draw_popup_text(
     let language = view.language;
     let cell_w = size.cell_width();
     let cell_h = size.cell_height();
-    let geometry = settings_geometry(size, scale, view.area, view.scroll, view.hidden_hosts.len());
+    let geometry = settings_geometry(
+        size,
+        scale,
+        view.area,
+        view.scroll,
+        view.hidden_hosts.len(),
+        view.density,
+    );
     // 背景色浮层：hex 草稿（或占位提示）画进输入框，色板格无文字。
     if dropdown == SettingsDropdown::BackgroundColor {
         if view.section != NebulaSettingsSection::Appearance {
@@ -2776,7 +2809,14 @@ pub(super) fn draw_text(
     let sk = view.theme.skin();
     let language = view.language;
 
-    let geometry = settings_geometry(size, scale, view.area, view.scroll, view.hidden_hosts.len());
+    let geometry = settings_geometry(
+        size,
+        scale,
+        view.area,
+        view.scroll,
+        view.hidden_hosts.len(),
+        view.density,
+    );
     // Kept for parity with [`draw_popup_text`]'s shell icons; the base page
     // currently stages no icon draws of its own.
     let icon_draws = Vec::new();

--- a/nebula_app/src/display/ssh_connect.rs
+++ b/nebula_app/src/display/ssh_connect.rs
@@ -17,7 +17,7 @@ use unicode_width::UnicodeWidthChar;
 use super::color::Rgb;
 use super::i18n::UiLanguage;
 use super::ui::icons;
-use super::ui::tokens::{radius, space, type_scale};
+use super::ui::tokens::{Density, radius, space, type_scale};
 use super::{NebulaTheme, SizeInfo};
 use crate::renderer::ui::{Gradient, Rgba, UiQuad};
 use crate::renderer::{GlyphCache, Renderer};
@@ -235,12 +235,14 @@ fn button_specs(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn layout(
     state: &SshConnectState,
     size: &SizeInfo,
     view: (f32, f32, f32, f32),
     scale: f32,
     language: UiLanguage,
+    density: Density,
 ) -> Layout {
     let s = |v: f32| v * scale;
     let pad = s(space::L);
@@ -271,7 +273,7 @@ fn layout(
         // 留下一大块空框，读起来像"还有内容没加载出来"。
         let rows = state.log.len().clamp(1, LOG_ROWS);
         let inner = ch * type_scale::SUPPORTING * rows as f32 + s(space::S) * 2.0;
-        h += s(space::M) + inner;
+        h += s(space::major(density)) + inner;
         Some(inner)
     } else {
         None
@@ -285,7 +287,7 @@ fn layout(
     let card_y = (view.1 + (view.3 - h) * 0.5).round();
 
     let icon_x = card_x + pad;
-    let text_x = icon_x + icon_h + s(space::M);
+    let text_x = icon_x + icon_h + s(space::major(density));
     // 两行身份文字在图标高度内垂直居中。
     let name_line = ch * type_scale::BODY;
     let meta_line = ch * type_scale::SUPPORTING;
@@ -294,7 +296,9 @@ fn layout(
 
     // Logs 按钮贴卡片右内缘，与图标同一条水平中线。
     let logs_label = language.pick("Logs", "Logs");
-    let logs_w = text_w(logs_label, cell_w, type_scale::SUPPORTING) + s(space::M) * 2.0 + s(10.0);
+    let logs_w = text_w(logs_label, cell_w, type_scale::SUPPORTING)
+        + s(space::major(density)) * 2.0
+        + s(10.0);
     let logs_btn = (
         (card_x + card_w - pad - logs_w).round(),
         (card_y + icon_top + (icon_h - s(BTN_H)) * 0.5).round(),
@@ -306,7 +310,8 @@ fn layout(
     let mut buttons = Vec::new();
     let mut right = card_x + card_w - pad;
     for (label, hit, primary) in button_specs(state, language).into_iter().rev() {
-        let w = (text_w(&label, cell_w, type_scale::BODY) + s(space::M) * 2.0).max(s(76.0));
+        let w = (text_w(&label, cell_w, type_scale::BODY) + s(space::major(density)) * 2.0)
+            .max(s(76.0));
         right -= w;
         buttons.push((
             ((right).round(), (card_y + btn_top).round(), w.round(), s(BTN_H)),
@@ -350,10 +355,11 @@ pub(super) fn hit_test(
     view: (f32, f32, f32, f32),
     scale: f32,
     language: UiLanguage,
+    density: Density,
     x: f32,
     y: f32,
 ) -> SshConnectHit {
-    let l = layout(state, size, view, scale, language);
+    let l = layout(state, size, view, scale, language, density);
     if contains(l.logs_btn, x, y) {
         return SshConnectHit::Logs;
     }
@@ -398,9 +404,10 @@ pub(super) fn push_quads(
     view: (f32, f32, f32, f32),
     scale: f32,
     language: UiLanguage,
+    density: Density,
     backdrop: Rgba,
 ) {
-    let l = layout(state, size, view, scale, language);
+    let l = layout(state, size, view, scale, language, density);
     let s = |v: f32| v * scale;
     let sk = theme.skin();
     let palette = theme.palette();
@@ -434,24 +441,28 @@ pub(super) fn push_quads(
             cy,
             cw,
             chh,
-            s(radius::OVERLAY),
+            s(radius::overlay(density)),
             s(20.0),
             s(7.0),
             Rgba::new(0, 0, 0, shadow_alpha),
         )
         .pixel_snapped(),
     );
-    quads.push(UiQuad::solid(cx, cy, cw, chh, s(radius::OVERLAY), sk.panel).pixel_snapped());
+    quads.push(
+        UiQuad::solid(cx, cy, cw, chh, s(radius::overlay(density)), sk.panel).pixel_snapped(),
+    );
     // hairline 描边：与阴影二选一会显薄，浮层这一层两者都要（阴影给高度，
     // 描边给边界），但描边只有 1px 且极淡。
-    quads.push(UiQuad::solid(cx, cy, cw, chh, s(radius::OVERLAY), sk.hairline).pixel_snapped());
+    quads.push(
+        UiQuad::solid(cx, cy, cw, chh, s(radius::overlay(density)), sk.hairline).pixel_snapped(),
+    );
     quads.push(
         UiQuad::solid(
             cx + s(1.0),
             cy + s(1.0),
             cw - s(2.0),
             chh - s(2.0),
-            s(radius::OVERLAY) - s(1.0),
+            s(radius::overlay(density)) - s(1.0),
             sk.panel,
         )
         .pixel_snapped(),
@@ -464,7 +475,9 @@ pub(super) fn push_quads(
     // 这正是 icons.rs 里 blend_over 存在的理由。先算出真实的不透明底色。
     let solid_panel = icons::blend_over(backdrop, sk.panel);
     let solid_card = icons::blend_over(solid_panel, sk.card);
-    quads.push(UiQuad::solid(ix, iy, iw, ih, s(radius::CONTROL), solid_card).pixel_snapped());
+    quads.push(
+        UiQuad::solid(ix, iy, iw, ih, s(radius::control(density)), solid_card).pixel_snapped(),
+    );
     // 服务器机架墨迹：两层机箱 + 各一颗指示灯。字体私用区字形在分数 DPI 下
     // 会漂，所以和 icons.rs 一样走矢量，不借字形。
     {
@@ -650,14 +663,14 @@ pub(super) fn push_quads(
     push_button_frame(
         quads,
         l.logs_btn,
-        s(radius::CONTROL),
+        s(radius::control(density)),
         false,
         state.hover == SshConnectHit::Logs,
         sk,
     );
     {
         let (bx, by, bw, bh) = l.logs_btn;
-        let cxx = bx + bw - s(space::M) - s(3.0);
+        let cxx = bx + bw - s(space::major(density)) - s(3.0);
         let cyy = by + bh * 0.5;
         let arm = s(3.2);
         let stroke = (s(1.3)).max(1.0);
@@ -683,7 +696,7 @@ pub(super) fn push_quads(
     // ── 日志区 ─────────────────────────────────────────────────
     if let Some(area) = l.logs_area {
         quads.push(
-            UiQuad::solid(area.0, area.1, area.2, area.3, s(radius::CONTROL), sk.hairline)
+            UiQuad::solid(area.0, area.1, area.2, area.3, s(radius::control(density)), sk.hairline)
                 .pixel_snapped(),
         );
         let inset = s(1.0);
@@ -693,7 +706,7 @@ pub(super) fn push_quads(
                 area.1 + inset,
                 area.2 - inset * 2.0,
                 area.3 - inset * 2.0,
-                s(radius::CONTROL) - inset,
+                s(radius::control(density)) - inset,
                 sk.card,
             )
             .pixel_snapped(),
@@ -702,7 +715,14 @@ pub(super) fn push_quads(
 
     // ── 底部按钮 ───────────────────────────────────────────────
     for (rect, hit, primary) in &l.buttons {
-        push_button_frame(quads, *rect, s(radius::CONTROL), *primary, state.hover == *hit, sk);
+        push_button_frame(
+            quads,
+            *rect,
+            s(radius::control(density)),
+            *primary,
+            state.hover == *hit,
+            sk,
+        );
     }
 }
 
@@ -798,8 +818,9 @@ pub(super) fn draw_text(
     size: &SizeInfo,
     view: (f32, f32, f32, f32),
     scale: f32,
+    density: Density,
 ) {
-    let l = layout(state, size, view, scale, language);
+    let l = layout(state, size, view, scale, language, density);
     let sk = theme.skin();
     let cell_w = size.cell_width();
 
@@ -913,7 +934,7 @@ pub(super) fn draw_text(
     // Logs 开关的标签（箭头是矢量，在 push_quads 里）。
     r.draw_ui_text(
         size,
-        (l.logs_btn.0 + space::M * scale).round(),
+        (l.logs_btn.0 + space::major(density) * scale).round(),
         (l.logs_btn.1 + (l.logs_btn.3 - size.cell_height() * type_scale::SUPPORTING) * 0.5).round(),
         type_scale::SUPPORTING,
         sk.ink_dim,
@@ -1162,18 +1183,36 @@ mod tests {
         let size = probe_size();
         let lang = UiLanguage::EnUs;
         let state = SshConnectState::new("root@h".into());
-        let l = layout(&state, &size, VIEW, 1.0, lang);
+        let l = layout(&state, &size, VIEW, 1.0, lang, Density::Standard);
 
         let (bx, by, bw, bh) = l.logs_btn;
         assert_eq!(
-            hit_test(&state, &size, VIEW, 1.0, lang, bx + bw * 0.5, by + bh * 0.5),
+            hit_test(
+                &state,
+                &size,
+                VIEW,
+                1.0,
+                lang,
+                Density::Standard,
+                bx + bw * 0.5,
+                by + bh * 0.5
+            ),
             SshConnectHit::Logs
         );
 
         let (rect, hit, _) = l.buttons[0];
         assert_eq!(hit, SshConnectHit::Cancel, "连接中只该有取消");
         assert_eq!(
-            hit_test(&state, &size, VIEW, 1.0, lang, rect.0 + rect.2 * 0.5, rect.1 + rect.3 * 0.5),
+            hit_test(
+                &state,
+                &size,
+                VIEW,
+                1.0,
+                lang,
+                Density::Standard,
+                rect.0 + rect.2 * 0.5,
+                rect.1 + rect.3 * 0.5
+            ),
             SshConnectHit::Cancel
         );
     }
@@ -1184,12 +1223,21 @@ mod tests {
         let lang = UiLanguage::EnUs;
         let mut state = SshConnectState::new("root@h".into());
         state.set_stage(SshStage::Failed("boom".into()));
-        let l = layout(&state, &size, VIEW, 1.0, lang);
+        let l = layout(&state, &size, VIEW, 1.0, lang, Density::Standard);
         let (rect, hit, primary) = l.buttons[0];
         assert_eq!(hit, SshConnectHit::Close);
         assert!(primary, "唯一动作应当是主按钮");
         assert_eq!(
-            hit_test(&state, &size, VIEW, 1.0, lang, rect.0 + rect.2 * 0.5, rect.1 + rect.3 * 0.5),
+            hit_test(
+                &state,
+                &size,
+                VIEW,
+                1.0,
+                lang,
+                Density::Standard,
+                rect.0 + rect.2 * 0.5,
+                rect.1 + rect.3 * 0.5
+            ),
             SshConnectHit::Close
         );
     }
@@ -1207,11 +1255,11 @@ mod tests {
         let size = probe_size();
         let lang = UiLanguage::EnUs;
         let mut state = SshConnectState::new("root@h".into());
-        let before = layout(&state, &size, VIEW, 1.0, lang).card;
+        let before = layout(&state, &size, VIEW, 1.0, lang, Density::Standard).card;
         state.toggle_logs();
-        let after = layout(&state, &size, VIEW, 1.0, lang).card;
+        let after = layout(&state, &size, VIEW, 1.0, lang, Density::Standard).card;
         assert!(after.3 > before.3, "展开日志应当长高");
         assert_eq!(after.2, before.2, "宽度不该跟着变，否则读起来像在抖");
-        assert!(layout(&state, &size, VIEW, 1.0, lang).logs_area.is_some());
+        assert!(layout(&state, &size, VIEW, 1.0, lang, Density::Standard).logs_area.is_some());
     }
 }

--- a/nebula_app/src/display/ssh_editor_render.rs
+++ b/nebula_app/src/display/ssh_editor_render.rs
@@ -556,6 +556,7 @@ impl Display {
             stage_radius,
             scale,
             &skin,
+            self.nebula_density,
             super::ui::surface::Elevation::Modal,
             progress,
         );
@@ -579,7 +580,14 @@ impl Display {
         // 分组卡片：hairline 环 + card 内芯，两者由 `push_group` 合成成一个
         // 不透明填充。分开画会让描边色渗满整张卡（见该函数的注释）。
         for group in [conn_group, auth_group] {
-            super::ui::surface::push_group(&mut quads, group, scale, &skin, progress);
+            super::ui::surface::push_group(
+                &mut quads,
+                group,
+                scale,
+                &skin,
+                self.nebula_density,
+                progress,
+            );
         }
         // 卡片内芯的实色。卡片里再嵌的东西（分段轨道）要拿它当底做合成。
         let group_fill = super::ui::surface::over(skin.card, skin.panel);
@@ -1354,6 +1362,7 @@ impl Display {
                 stage_radius,
                 scale,
                 &skin,
+                self.nebula_density,
                 super::ui::surface::Elevation::Menu,
                 1.0,
             );

--- a/nebula_app/src/display/ui/surface.rs
+++ b/nebula_app/src/display/ui/surface.rs
@@ -21,7 +21,7 @@
 //! popover，要求决策、有后果的是 modal。
 
 use super::theme::Skin;
-use super::tokens::{control, elevation, radius};
+use super::tokens::{Density, control, elevation, radius};
 use crate::renderer::ui::{Rgba, UiQuad};
 
 /// `(x, y, width, height)`，逻辑像素。
@@ -101,6 +101,7 @@ pub fn over(top: Rgba, base: Rgba) -> Rgba {
     Rgba::new(mix(top.r, base.r), mix(top.g, base.g), mix(top.b, base.b), base.a)
 }
 
+
 /// 发丝描边环。替代散落各处的手写 `(x-1, y-1, w+2, h+2)`。
 ///
 /// 外圆角自动取 `radius + hairline`，保证内外弧**同心**——手写处常常内外用同一
@@ -124,12 +125,14 @@ pub fn push_stroke(quads: &mut Vec<UiQuad>, rect: Rect, radius: f32, scale: f32,
 ///
 /// `viewport` 是整窗尺寸 `(width, height)`，只有模态用得上。
 /// `progress` 是入场动画进度，所有颜色按它衰减。
+#[allow(clippy::too_many_arguments)]
 pub fn push_surface(
     quads: &mut Vec<UiQuad>,
     rect: Rect,
     viewport: (f32, f32),
     scale: f32,
     sk: &Skin,
+    density: Density,
     level: Elevation,
     progress: f32,
 ) {
@@ -140,6 +143,7 @@ pub fn push_surface(
         0.0,
         scale,
         sk,
+        density,
         level,
         progress,
     );
@@ -162,11 +166,14 @@ pub fn push_surface_in(
     veil_radius: f32,
     scale: f32,
     sk: &Skin,
+    density: Density,
     level: Elevation,
     progress: f32,
 ) {
     let (x, y, w, h) = rect;
-    let corner = radius::OVERLAY * scale;
+    // 密度作为显式参数进来，而不是塞进 `Skin`——主题与密度是正交轴，皮肤
+    // 的每个字段都是颜色。层契约「输入是矩形和 Skin，不读配置」仍然成立。
+    let corner = radius::overlay(density) * scale;
 
     if level.dims_background() {
         quads.push(UiQuad::solid(
@@ -205,9 +212,16 @@ pub fn push_surface_in(
 }
 
 /// 浮层内部的内容块。
-pub fn push_card(quads: &mut Vec<UiQuad>, rect: Rect, scale: f32, sk: &Skin, state: CardState) {
+pub fn push_card(
+    quads: &mut Vec<UiQuad>,
+    rect: Rect,
+    scale: f32,
+    sk: &Skin,
+    density: Density,
+    state: CardState,
+) {
     let (x, y, w, h) = rect;
-    let corner = radius::OVERLAY * scale;
+    let corner = radius::overlay(density) * scale;
     let fill = match state {
         CardState::Default => sk.card,
         CardState::Hover => sk.hover,
@@ -227,17 +241,31 @@ pub fn push_card(quads: &mut Vec<UiQuad>, rect: Rect, scale: f32, sk: &Skin, sta
 /// (50,52,62)，再叠 card 得 (62,65,74)，而原型是 (56,61,73)。所以这里把
 /// `card` 与 `panel` 预先合成成一个**不透明**色，一个 quad 画完，描边环也
 /// 就只剩它该有的那 1px。
-pub fn push_group(quads: &mut Vec<UiQuad>, rect: Rect, scale: f32, sk: &Skin, progress: f32) {
+pub fn push_group(
+    quads: &mut Vec<UiQuad>,
+    rect: Rect,
+    scale: f32,
+    sk: &Skin,
+    density: Density,
+    progress: f32,
+) {
     let (x, y, w, h) = rect;
-    let corner = radius::OVERLAY * scale;
+    let corner = radius::overlay(density) * scale;
     push_stroke(quads, rect, corner, scale, fade(sk.hairline, progress));
     quads.push(UiQuad::solid(x, y, w, h, corner, fade(over(sk.card, sk.panel), progress)));
 }
 
 /// 下沉表面（文本输入框）。聚焦时描边换成强调色——焦点不能只靠颜色深浅表示。
-pub fn push_input(quads: &mut Vec<UiQuad>, rect: Rect, scale: f32, sk: &Skin, focused: bool) {
+pub fn push_input(
+    quads: &mut Vec<UiQuad>,
+    rect: Rect,
+    scale: f32,
+    sk: &Skin,
+    density: Density,
+    focused: bool,
+) {
     let (x, y, w, h) = rect;
-    let corner = radius::CONTROL * scale;
+    let corner = radius::control(density) * scale;
     let stroke =
         if focused { Rgba::new(sk.accent.r, sk.accent.g, sk.accent.b, 255) } else { sk.hairline };
     push_stroke(quads, rect, corner, scale, stroke);
@@ -260,7 +288,7 @@ mod tests {
         // 会让描边色渗满整张卡片，把它压深一整档。所以内芯必须不透明。
         for skin in [light(), NebulaTheme::Nebula.skin()] {
             let mut quads = Vec::new();
-            push_group(&mut quads, (40.0, 40.0, 300.0, 120.0), 1.0, &skin, 1.0);
+            push_group(&mut quads, (40.0, 40.0, 300.0, 120.0), 1.0, &skin, Density::Standard, 1.0);
 
             assert_eq!(quads.len(), 2, "只该有描边环和内芯两个 quad");
             assert_eq!(quads[1].color0.a, 255, "内芯必须不透明，否则描边渗出来");
@@ -319,6 +347,7 @@ mod tests {
                 (800.0, 600.0),
                 1.0,
                 &sk,
+                Density::Standard,
                 level,
                 1.0,
             );
@@ -336,11 +365,35 @@ mod tests {
             (800.0, 600.0),
             1.0,
             &sk,
+            Density::Standard,
             Elevation::Modal,
             1.0,
         );
         let veil = &quads[0];
         assert_eq!((veil.x, veil.y, veil.width, veil.height), (0.0, 0.0, 800.0, 600.0));
+    }
+
+    #[test]
+    fn compact_surfaces_reuse_the_control_radius_instead_of_a_new_value() {
+        // 紧凑不是「另一套圆角」，而是同一阶梯降一档。这里从配方产出的
+        // quad 上验证：紧凑浮层的圆角恰好等于标准档控件圆角。
+        let sk = light();
+        let corner_of = |density| {
+            let mut quads = Vec::new();
+            push_surface(
+                &mut quads,
+                (10.0, 10.0, 100.0, 60.0),
+                (800.0, 600.0),
+                1.0,
+                &sk,
+                density,
+                Elevation::Menu,
+                1.0,
+            );
+            quads.last().expect("面板填充是最后一个 quad").radius
+        };
+        assert_eq!(corner_of(Density::Standard), radius::OVERLAY);
+        assert_eq!(corner_of(Density::Compact), radius::CONTROL);
     }
 
     #[test]

--- a/nebula_app/src/display/ui/tokens.rs
+++ b/nebula_app/src/display/ui/tokens.rs
@@ -107,6 +107,14 @@ pub mod control {
     pub fn settings_row(density: Density) -> f32 {
         if density.compact() { COMPACT_ROW } else { ROW }
     }
+
+    /// 本来就密的列表行（命令面板、弹层列表）。标准档已经站在
+    /// [`COMPACT_ROW`] 上，所以紧凑再降一格落到 [`MIN_HIT_TARGET`]——阶梯
+    /// 的最后一档，也是不该再往下走的硬下界。
+    #[inline]
+    pub fn dense_row(density: Density) -> f32 {
+        if density.compact() { MIN_HIT_TARGET } else { COMPACT_ROW }
+    }
 }
 
 /// 浮层的 Z 轴处理。阴影按浮层面积分档——同一组参数放在小菜单上刚好，
@@ -211,6 +219,9 @@ mod tests {
         assert_eq!(control::row(Density::Compact), control::MIN_HIT_TARGET);
         assert_eq!(control::settings_row(Density::Standard), control::ROW);
         assert_eq!(control::settings_row(Density::Compact), control::COMPACT_ROW);
+        // 本来就密的列表比设置行低一档起步，紧凑之后落到阶梯末端。
+        assert_eq!(control::dense_row(Density::Standard), control::COMPACT_ROW);
+        assert_eq!(control::dense_row(Density::Compact), control::MIN_HIT_TARGET);
     }
 
     #[test]
@@ -219,6 +230,7 @@ mod tests {
         for density in [Density::Standard, Density::Compact] {
             assert!(control::row(density) >= control::MIN_HIT_TARGET);
             assert!(control::settings_row(density) >= control::MIN_HIT_TARGET);
+            assert!(control::dense_row(density) >= control::MIN_HIT_TARGET);
         }
     }
 

--- a/nebula_app/src/display/ui/tokens.rs
+++ b/nebula_app/src/display/ui/tokens.rs
@@ -9,13 +9,39 @@
 // `s(16.0)`（= space::M）、31 个 `s(8.0)`（= radius::OVERLAY）。
 #![allow(dead_code)]
 
+/// 界面密度。紧凑档不引入任何新的视觉数值，只在既有的间距与圆角阶梯上
+/// 取更小一档——紧凑不是另一套审美，是同一套审美的更密档位。
+///
+/// 决策与理由见 ADR-0002。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Density {
+    #[default]
+    Standard,
+    Compact,
+}
+
+impl Density {
+    #[inline]
+    const fn compact(self) -> bool {
+        matches!(self, Self::Compact)
+    }
+}
+
 pub mod space {
+    use super::Density;
+
     pub const XXS: f32 = 4.0;
     pub const XS: f32 = 8.0;
     pub const S: f32 = 12.0;
     pub const M: f32 = 16.0;
     pub const L: f32 = 24.0;
     pub const XL: f32 = 32.0;
+
+    /// 主留白。紧凑降一档：`M` → `S`。
+    #[inline]
+    pub fn major(density: Density) -> f32 {
+        if density.compact() { S } else { M }
+    }
 }
 
 /// 圆角阶梯。逐层递减：浮层 → 控件 → chip。
@@ -25,6 +51,8 @@ pub mod space {
 /// （命令面板 14、设置模态 12、确认框 12、AI 条 10、右键菜单 9、popup 8），
 /// 这是界面"不成体系"的直接来源。
 pub mod radius {
+    use super::Density;
+
     /// 浮层：命令面板、模态、右键菜单、下拉 popup。
     pub const OVERLAY: f32 = 8.0;
     /// 控件：combobox、spinner、输入框、按钮。
@@ -32,6 +60,18 @@ pub mod radius {
     pub const CONTROL: f32 = 6.0;
     /// chip / 键帽 / 徽标。
     pub const CHIP: f32 = 4.0;
+
+    /// 浮层圆角。紧凑整档下移：`OVERLAY` → `CONTROL`。
+    #[inline]
+    pub fn overlay(density: Density) -> f32 {
+        if density.compact() { CONTROL } else { OVERLAY }
+    }
+
+    /// 控件圆角。紧凑整档下移：`CONTROL` → `CHIP`。
+    #[inline]
+    pub fn control(density: Density) -> f32 {
+        if density.compact() { CHIP } else { CONTROL }
+    }
 }
 
 pub mod type_scale {
@@ -44,6 +84,8 @@ pub mod type_scale {
 }
 
 pub mod control {
+    use super::Density;
+
     pub const ICON_BUTTON: f32 = 20.0;
     pub const MIN_HIT_TARGET: f32 = 32.0;
     /// Dense rows used by command/search pickers where several choices must
@@ -51,6 +93,20 @@ pub mod control {
     pub const COMPACT_ROW: f32 = 38.0;
     pub const ROW: f32 = 44.0;
     pub const HAIRLINE: f32 = 1.0;
+
+    /// 普通行高。紧凑降到最小点击目标——那既是阶梯上的既有值，也是密度
+    /// 收紧的硬下界。
+    #[inline]
+    pub fn row(density: Density) -> f32 {
+        if density.compact() { MIN_HIT_TARGET } else { ROW }
+    }
+
+    /// 设置页行高。紧凑用既有的 [`COMPACT_ROW`]，它本就是为「多选项同时
+    /// 可见而输入框不喧宾夺主」定的密行高。
+    #[inline]
+    pub fn settings_row(density: Density) -> f32 {
+        if density.compact() { COMPACT_ROW } else { ROW }
+    }
 }
 
 /// 浮层的 Z 轴处理。阴影按浮层面积分档——同一组参数放在小菜单上刚好，
@@ -135,7 +191,41 @@ impl ControlState {
 
 #[cfg(test)]
 mod tests {
-    use super::ControlState;
+    use super::{ControlState, Density, control, radius, space};
+
+    /// 紧凑档的每一个值都必须是阶梯上**已经存在**的常量。
+    ///
+    /// 这条断言就是「不引入新的视觉数值」合同的可执行形式：一旦有人给紧凑
+    /// 档写了个新数字，它就不再等于任何一档，测试立刻变红。
+    #[test]
+    fn compact_steps_down_the_existing_ladder_without_inventing_values() {
+        assert_eq!(radius::overlay(Density::Standard), radius::OVERLAY);
+        assert_eq!(radius::overlay(Density::Compact), radius::CONTROL);
+        assert_eq!(radius::control(Density::Standard), radius::CONTROL);
+        assert_eq!(radius::control(Density::Compact), radius::CHIP);
+
+        assert_eq!(space::major(Density::Standard), space::M);
+        assert_eq!(space::major(Density::Compact), space::S);
+
+        assert_eq!(control::row(Density::Standard), control::ROW);
+        assert_eq!(control::row(Density::Compact), control::MIN_HIT_TARGET);
+        assert_eq!(control::settings_row(Density::Standard), control::ROW);
+        assert_eq!(control::settings_row(Density::Compact), control::COMPACT_ROW);
+    }
+
+    #[test]
+    fn compact_never_drops_below_the_minimum_hit_target() {
+        // 密度可以收紧留白，但不能把可交互目标压到手指够不着。
+        for density in [Density::Standard, Density::Compact] {
+            assert!(control::row(density) >= control::MIN_HIT_TARGET);
+            assert!(control::settings_row(density) >= control::MIN_HIT_TARGET);
+        }
+    }
+
+    #[test]
+    fn standard_is_the_upstream_compatible_default() {
+        assert_eq!(Density::default(), Density::Standard);
+    }
 
     #[test]
     fn persistent_control_states_outrank_hover() {

--- a/nebula_app/src/display/ui/widgets.rs
+++ b/nebula_app/src/display/ui/widgets.rs
@@ -13,7 +13,7 @@
 use super::icons;
 use super::surface;
 use super::theme::Skin;
-use super::tokens::radius;
+use super::tokens::{Density, radius};
 use crate::renderer::ui::{Rgba, UiQuad};
 
 pub(crate) type Rect = (f32, f32, f32, f32);
@@ -209,12 +209,22 @@ pub(crate) fn push_combobox_popup(
     hover: Option<usize>,
     scale: f32,
     sk: &Skin,
+    density: Density,
 ) {
     let s = |v: f32| v * scale;
     // 层级走 Menu：真外阴影 + 同心描边 + 不透明底。此前这里是
     // `UiQuad::glow` —— glow 向外扩散亮度，不建立高度关系，在浅色主题上
     // 只会让下拉四周发灰，看着像脏了一圈而不是浮起来。
-    surface::push_surface(quads, popup, (0.0, 0.0), scale, sk, surface::Elevation::Menu, 1.0);
+    surface::push_surface(
+        quads,
+        popup,
+        (0.0, 0.0),
+        scale,
+        sk,
+        density,
+        surface::Elevation::Menu,
+        1.0,
+    );
     quads.push(UiQuad::solid(
         popup.0,
         popup.1,

--- a/nebula_app/src/input/chrome.rs
+++ b/nebula_app/src/input/chrome.rs
@@ -862,6 +862,18 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                         self.ctx.mark_dirty();
                         return;
                     },
+                    crate::display::SettingsHit::DensityDropdown => {
+                        self.ctx
+                            .display()
+                            .toggle_settings_dropdown(crate::display::SettingsDropdown::Density);
+                        self.ctx.mark_dirty();
+                        return;
+                    },
+                    crate::display::SettingsHit::DensityOption(index) => {
+                        self.ctx.display().set_density_option(index);
+                        self.ctx.mark_dirty();
+                        return;
+                    },
                     crate::display::SettingsHit::FontSizeUp => {
                         let ui_scale = self.ctx.display().window.scale_factor as f32;
                         self.ctx.change_font_size(ui_scale);
@@ -1292,6 +1304,8 @@ fn settings_dropdown_keeps_open(hit: crate::display::SettingsHit) -> bool {
             | Hit::AcceptOption(_)
             | Hit::TabRevealDropdown
             | Hit::TabRevealOption(_)
+            | Hit::DensityDropdown
+            | Hit::DensityOption(_)
             | Hit::CursorShapeDropdown
             | Hit::CursorShapeOption(_)
             | Hit::BackgroundColor

--- a/nebula_app/src/input/chrome.rs
+++ b/nebula_app/src/input/chrome.rs
@@ -746,6 +746,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                     shell_picker_count,
                     font_picker_count,
                     hidden_host_count,
+                    self.ctx.display().nebula_density,
                 );
                 // 打开的下拉框独占第一击：命中不属于它（选项行或锚行）时，
                 // 这一击只负责关闭浮层，绝不让下层控件借机误触发。

--- a/nebula_app/src/input/mouse.rs
+++ b/nebula_app/src/input/mouse.rs
@@ -244,6 +244,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             shell_picker_count,
             font_picker_count,
             hidden_host_count,
+            self.ctx.display().nebula_density,
         );
         let chrome_hover = if crate::display::in_chrome_bar(&window_size, scale, x as f32, y as f32)
         {

--- a/nebula_app/src/input/mouse.rs
+++ b/nebula_app/src/input/mouse.rs
@@ -331,6 +331,8 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             | crate::display::SettingsHit::KeymapRow(_)
             | crate::display::SettingsHit::TabRevealDropdown
             | crate::display::SettingsHit::TabRevealOption(_)
+            | crate::display::SettingsHit::DensityDropdown
+            | crate::display::SettingsHit::DensityOption(_)
             | crate::display::SettingsHit::FontSizeUp
             | crate::display::SettingsHit::FontSizeDown
             | crate::display::SettingsHit::BackgroundImageCoverChrome


### PR DESCRIPTION
### 功能

让用户在**界面外观预设**「标准 / 紧凑」之间切换，协调控制 Nebula 原生界面的密度与轮廓风格。

- 标准保持上游当前外观并作为兼容默认；紧凑减少留白、收小圆角、去除装饰性光晕
- 覆盖顶栏、侧栏、设置、命令面板、文件抽屉、对话框与终端周围留白
- **不引入任何新的视觉数值**：留白由主间距降到次间距，行高由标准行降到最小点击目标，设置行直接使用既有的紧凑行，圆角整体下移一档（在既有间距与圆角阶梯上取更小一档，见 ADR-0002）
- 降档以关系函数表达而非平行常量表：`radius::overlay(density)`、`radius::control(density)`、`space::major(density)`、`control::row(density)`、`control::settings_row(density)` —— 调用点写函数调用而非数字字面量

### 与 guardrails 的关系

上游视觉强约束的扫描器（三个违规预算：圆角 / 手写描边 / 辉光）是验收合同：**预算必须保持原值**——上升意味着新增技术债，下降意味着顺手清理了存量，两者都会让构建变红。本 PR 保持三个预算一字未动（v0.9 水平 69/45/9），由仓库内建的 guardrails 测试守护。

### 验证

- 分支 `pr/compact-appearance`，HEAD `426e560`，基于 `31fc791`（batch-0.9-baseline）
- `cargo test -p nebula --bin nebula` 通过（含新增测试），workspace 全量通过；`cargo check --workspace --release` 0 错误
- guardrails 预算 69/45/9 保持不变（guardrails 测试全过）
- 差异边界：产品源码 + 测试，无本地工作流文档、无占位、无构建产物
- 上游等价性：基线检查确认上游无等价的密度/外观预设

### 维护者承诺

按 ADR-0001（批次贡献模型）：本分支与本批次其他 PR 互不包含对方提交。**任一前项合并后，贡献方会立即把本分支重基到最新上游并解决机械冲突**——冲突成本由贡献方而非维护者承担。
