### PR TITLE
fix: restore the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,10 +453,10 @@ Apache-2.0 许可发布，Nebula 通过带少量补丁的 fork 使用，版本�
 
 ## ⭐ Star History
 
-<a href="https://star-history.com/#Kuddev/nebula&Date">
+<a href="https://star-history.dera.page/#Kuddev/nebula&type=date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Kuddev/nebula&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Kuddev/nebula&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Kuddev/nebula&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Kuddev/nebula&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Kuddev/nebula&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Kuddev/nebula&type=Date" />
   </picture>
 </a>


### PR DESCRIPTION
The current star history chart is broken and no longer renders reliably. Update the README chart links so the project star history is available again.