### PR TITLE
gpui: permanent mute for multi-line paste confirmation

### DIFF
--- a/nebula_app/src/gpui_shell/settings_pane.rs
+++ b/nebula_app/src/gpui_shell/settings_pane.rs
@@ -3034,6 +3034,13 @@ impl SettingsPane {
                         cx,
                     ))
                     .child(self.switch_row(
+                        "multiline_paste_confirm",
+                        "多行粘贴前询问（关 = 永久直接粘贴）",
+                        "开：粘贴 ≥20 行时弹确认框；关：不弹直接粘贴。",
+                        self.runtime.multiline_paste_confirm,
+                        cx,
+                    ))
+                    .child(self.switch_row(
                         "panel_resize",
                         "拖拽调节侧栏宽度",
                         "关掉后侧栏与面板的分界线钉死，拖不动；宽度仍可在别处改，只是不会被误拖。",

--- a/nebula_app/src/gpui_shell/terminal/view.rs
+++ b/nebula_app/src/gpui_shell/terminal/view.rs
@@ -13,6 +13,8 @@ use gpui::{
     Styled as _, TextRun, UTF16Selection, Window, div, point, px,
 };
 use gpui_component::WindowExt as _;
+use gpui_component::checkbox::Checkbox;
+use gpui_component::Sizable as _;
 use nebula_settings::CellWidthModeName;
 use nebula_terminal::event::{Event as TermEvent, Notify as _, OnResize as _, WindowSize};
 use nebula_terminal::event_loop::Msg;
@@ -1345,7 +1347,10 @@ impl TerminalView {
     pub fn paste(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) else { return };
         let lines = paste_line_count(&text);
-        if lines >= PASTE_CONFIRM_LINES {
+        // 「多行粘贴前询问」关闭时不再弹确认，直接 paste_now。
+        if lines >= PASTE_CONFIRM_LINES
+            && nebula_settings::RuntimeSettings::load().multiline_paste_confirm
+        {
             self.confirm_paste(text, lines, window, cx);
             return;
         }
@@ -1393,22 +1398,57 @@ impl TerminalView {
         // pane」的 view 释放不掉。
         let text = Arc::new(text);
         let view = cx.entity().downgrade();
+        // 「不再询问」勾选状态：确认按钮点上后先用 memory,on_ok UI 上直接写回设置。
+        let never_ask_again = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let ok_text2 = ok_text.clone();
+        let cancel_text2 = cancel_text.clone();
+        let title2 = title.clone();
+        let body2 = body.clone();
         window.open_dialog(cx, move |dialog, window, _cx| {
             let text = text.clone();
             let view = view.clone();
-            confirm_dialog(
+            let never_ask_again2 = never_ask_again.clone();
+            let dialog = confirm_dialog(
                 dialog,
                 window,
-                title.clone(),
-                body.clone(),
-                ok_text.clone(),
-                cancel_text.clone(),
+                title2.clone(),
+                body2.clone(),
+                ok_text2.clone(),
+                cancel_text2.clone(),
                 ButtonVariant::Primary,
-            )
-            .on_ok(move |_, _window, cx| {
-                let _ = view.update(cx, |this, cx| this.paste_now(&text, cx));
-                true
-            })
+            );
+            let never_ask_again_c = never_ask_again2.clone();
+            let view_c = view.clone();
+            dialog
+                .child(
+                    Checkbox::new("nebula-paste-never-ask")
+                        .label(match language {
+                            crate::display::UiLanguage::EnUs => "Don't ask again",
+                            _ => "不再询问",
+                        })
+                        .checked(false)
+                        .small()
+                        .on_click(move |_v, _window, _cx| {
+                            never_ask_again_c
+                                .store(true, std::sync::atomic::Ordering::Relaxed);
+                        }),
+                )
+                .on_ok({
+                    let never_ask_again = never_ask_again2.clone();
+                    let view = view_c;
+                    move |_, _window, cx| {
+                        if never_ask_again.load(std::sync::atomic::Ordering::Relaxed) {
+                            let _ = nebula_settings::persist_keys(&[(
+                                "multiline_paste_confirm",
+                                "0".to_string(),
+                            )]);
+                        }
+                        let _ = view.update(cx, |this, cx| {
+                            this.paste_now(&text, cx)
+                        });
+                        true
+                    }
+                })
         });
     }
 

--- a/nebula_settings/src/lib.rs
+++ b/nebula_settings/src/lib.rs
@@ -809,6 +809,9 @@ pub struct RuntimeSettings {
     pub cursor_shape: Option<CursorShapeName>,
     pub cursor_blink: Option<bool>,
     pub copy_on_select: bool,
+    /// 多行粘贴确认弹窗：开 = 粘贴 ≥20 行时弹确认；关 = 直接粘贴。
+    /// 上游默认开 (true)。
+    pub multiline_paste_confirm: bool,
     pub powerline: bool,
     /// 默认 shell 的原始 id（`shell=` 原文：powershell/bash/cmd/pwsh/WSL
     /// 发行版等）。解析归 shell 检测层，这里只做持久化往返。
@@ -902,6 +905,7 @@ impl RuntimeSettings {
             cursor_shape: raw.value("cursor_shape").and_then(CursorShapeName::from_settings),
             cursor_blink: raw.bool_on("cursor_blink"),
             copy_on_select: raw.bool_on("copy_on_select").unwrap_or(false),
+            multiline_paste_confirm: raw.bool_on("multiline_paste_confirm").unwrap_or(true),
             powerline: raw.bool_on("powerline").unwrap_or(true),
             shell: raw.value("shell").or_else(|| raw.value("executor")).map(str::to_owned),
             startup_directory: raw.value("startup_directory").map(str::to_owned),
@@ -1086,6 +1090,7 @@ mod tests {
         assert_eq!(settings.theme, ThemeName::Nebula);
         assert_eq!(settings.font_family, None);
         assert!(!settings.copy_on_select);
+        assert!(settings.multiline_paste_confirm, "多行粘贴确认默认开（上游兼容）");
         assert!(settings.powerline);
         assert!(settings.ghost);
         assert_eq!(settings.accept, AcceptKeyName::Both);


### PR DESCRIPTION
## What

Adds a setting to permanently disable the multi-line paste confirmation dialog (the 20+ lines gate). Two entry points write the same setting field:

1. Settings → Interaction → "多行粘贴前询问" switch (default on, upstream-compatible).
2. A "不再询问" checkbox on the confirmation dialog itself — checking it and confirming persists the same field via `persist_keys`.

## Details

- New `RuntimeSettings.multiline_paste_confirm: bool` (`nebula_settings`), default `true`.
- `paste()` in `terminal/view.rs` calls `paste_now` directly when the setting is off, skipping the modal.
- The checkbox uses a shared `Arc<AtomicBool` captured by the dialog so the single-shot flag survives dialog rebuilds.

## Test

- `nebula_settings` default-true assertion in the settings-round-trip test.
- Full bin suite passes under `--features gpui-shell`.