### PR TITLE
gpui: hide the tab close button via Appearance setting

### DIFF
--- a/nebula_app/src/gpui_shell/settings_pane.rs
+++ b/nebula_app/src/gpui_shell/settings_pane.rs
@@ -2249,6 +2249,13 @@ impl SettingsPane {
             ));
         let interface = self
             .group("界面", cx)
+            .child(self.switch_row(
+                "tab_close_visible",
+                "显示标签关闭按钮",
+                "关闭后侧栏与顶栏的标签都不再渲染叉号，中键点标签仍可关闭。",
+                self.runtime.tab_close_visible,
+                cx,
+            ))
             .child(self.select_row(
                 "language",
                 "语言",

--- a/nebula_app/src/gpui_shell/workspace/sidebar.rs
+++ b/nebula_app/src/gpui_shell/workspace/sidebar.rs
@@ -493,15 +493,20 @@ impl NebulaWorkspace {
                                 .items_center()
                                 .invisible()
                                 .group_hover(hover_group, |slot| slot.visible())
-                                .child(
-                                    Button::new(("close-tab", ix))
-                                        .icon(IconName::Close)
-                                        .ghost()
-                                        .xsmall()
-                                        .on_click(cx.listener(move |this, _, window, cx| {
-                                            cx.stop_propagation();
-                                            this.request_close_tab(ix, window, cx);
-                                        })),
+                                .when(
+                                    nebula_settings::RuntimeSettings::load().tab_close_visible,
+                                    |slot| {
+                                        slot.child(
+                                            Button::new(("close-tab", ix))
+                                                .icon(IconName::Close)
+                                                .ghost()
+                                                .xsmall()
+                                                .on_click(cx.listener(move |this, _, window, cx| {
+                                                    cx.stop_propagation();
+                                                    this.request_close_tab(ix, window, cx);
+                                                })),
+                                        )
+                                    },
                                 ),
                         ),
                 )

--- a/nebula_app/src/gpui_shell/workspace/top_tabs.rs
+++ b/nebula_app/src/gpui_shell/workspace/top_tabs.rs
@@ -408,17 +408,22 @@ impl NebulaWorkspace {
                                     .items_center()
                                     .invisible()
                                     .group_hover(hover_group, |slot| slot.visible())
-                                    .child(
-                                        Button::new(("top-close-tab", ix))
-                                            .icon(IconName::Close)
-                                            .ghost()
-                                            .xsmall()
-                                            .on_click(cx.listener(
-                                                move |this, _, window, cx| {
-                                                    cx.stop_propagation();
-                                                    this.request_close_tab(ix, window, cx);
-                                                },
-                                            )),
+                                    .when(
+                                        nebula_settings::RuntimeSettings::load().tab_close_visible,
+                                        |slot| {
+                                            slot.child(
+                                                Button::new(("top-close-tab", ix))
+                                                    .icon(IconName::Close)
+                                                    .ghost()
+                                                    .xsmall()
+                                                    .on_click(cx.listener(
+                                                        move |this, _, window, cx| {
+                                                            cx.stop_propagation();
+                                                            this.request_close_tab(ix, window, cx);
+                                                        },
+                                                    )),
+                                            )
+                                        },
                                     ),
                             ),
                     )

--- a/nebula_settings/src/lib.rs
+++ b/nebula_settings/src/lib.rs
@@ -809,6 +809,9 @@ pub struct RuntimeSettings {
     pub cursor_shape: Option<CursorShapeName>,
     pub cursor_blink: Option<bool>,
     pub copy_on_select: bool,
+    /// 标签页关闭按钮（叉号）是否渲染：关 = 不渲染，仍可用中键关闭。
+    /// 上游默认开 (true)。
+    pub tab_close_visible: bool,
     pub powerline: bool,
     /// 默认 shell 的原始 id（`shell=` 原文：powershell/bash/cmd/pwsh/WSL
     /// 发行版等）。解析归 shell 检测层，这里只做持久化往返。
@@ -902,6 +905,7 @@ impl RuntimeSettings {
             cursor_shape: raw.value("cursor_shape").and_then(CursorShapeName::from_settings),
             cursor_blink: raw.bool_on("cursor_blink"),
             copy_on_select: raw.bool_on("copy_on_select").unwrap_or(false),
+            tab_close_visible: raw.bool_on("tab_close_visible").unwrap_or(true),
             powerline: raw.bool_on("powerline").unwrap_or(true),
             shell: raw.value("shell").or_else(|| raw.value("executor")).map(str::to_owned),
             startup_directory: raw.value("startup_directory").map(str::to_owned),
@@ -1086,6 +1090,7 @@ mod tests {
         assert_eq!(settings.theme, ThemeName::Nebula);
         assert_eq!(settings.font_family, None);
         assert!(!settings.copy_on_select);
+        assert!(settings.tab_close_visible, "标签关闭按钮默认可见（上游兼容）");
         assert!(settings.powerline);
         assert!(settings.ghost);
         assert_eq!(settings.accept, AcceptKeyName::Both);


### PR DESCRIPTION
## What

Adds Settings → Appearance → 界面 → "显示标签关闭按钮" switch (default on, upstream-compatible). Turning it off stops rendering the close button (×) on tabs in both the sidebar tab list and the top title-bar tab strip. Middle-click close keeps working either way.

## Details

- New `RuntimeSettings.tab_close_visible: bool`, default `true`.
- Both close-button sites get wrapped in `.when(tab_close_visible, ...)`:
  - `workspace/sidebar.rs` ("close-tab" button)
  - `workspace/top_tabs.rs` ("top-close-tab" button)
- Hover-reveal semantics are unchanged when the setting is on.

## Test

- `nebula_settings` default-true assertion.
- Full bin suite passes under `--features gpui-shell`.