### PR TITLE
feat(gpui): Ctrl+C copies the selection, falling back to ^C

### DIFF
--- a/nebula_app/src/gpui_shell/workspace.rs
+++ b/nebula_app/src/gpui_shell/workspace.rs
@@ -173,6 +173,7 @@ const STATIC_DEFAULT_COMBOS: &[&str] = &[
     "ctrl--",
     "ctrl-0",
     "ctrl-shift-c",
+    "ctrl-c",
     "ctrl-v",
     "ctrl-shift-v",
     "alt-enter",
@@ -205,7 +206,11 @@ fn custom_workspace_binding(combo: &str, action: &crate::config::Action) -> Opti
         Action::IncreaseFontSize => Some(KeyBinding::new(&combo, IncreaseFontSize, None)),
         Action::DecreaseFontSize => Some(KeyBinding::new(&combo, DecreaseFontSize, None)),
         Action::ResetFontSize => Some(KeyBinding::new(&combo, ResetFontSize, None)),
-        Action::Copy => Some(KeyBinding::new(&combo, CopySelection, None)),
+        Action::Copy => Some(KeyBinding::new(
+            &combo,
+            CopySelection,
+            Some(crate::gpui_shell::terminal::KEY_CONTEXT),
+        )),
         Action::Paste => Some(KeyBinding::new(
             &combo,
             PasteClipboard,
@@ -235,7 +240,12 @@ fn gpui_binding_combo(combo: &str) -> String {
 
 /// 注册工作区快捷键；在 `gpui_component::init` 之后调用一次。
 pub fn init(cx: &mut App) {
-    cx.bind_keys([
+    cx.bind_keys(default_workspace_bindings());
+}
+
+/// 工作区静态默认键位表；与 [`STATIC_DEFAULT_COMBOS`] 互为镜像。
+fn default_workspace_bindings() -> Vec<KeyBinding> {
+    [
         KeyBinding::new("ctrl-shift-t", NewTerminal, None),
         KeyBinding::new("ctrl-shift-e", NewWindow, None),
         KeyBinding::new("ctrl-shift-w", CloseActiveTerminal, None),
@@ -271,6 +281,10 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("ctrl--", DecreaseFontSize, None),
         KeyBinding::new("ctrl-0", ResetFontSize, None),
         KeyBinding::new("ctrl-shift-c", CopySelection, None),
+        // 复制优先（WT 语义）：终端聚焦时有选区复制并清选区，无选区经 handler
+        // 的 `cx.propagate()` 落成 ^C。带终端上下文，重命名/输入框聚焦时
+        // ctrl+c 归输入框自己（Input -> Copy）。
+        KeyBinding::new("ctrl-c", CopySelection, Some(crate::gpui_shell::terminal::KEY_CONTEXT)),
         // 终端粘贴只在终端焦点路径命中。Input 自己带 `Input -> Paste`；这里若
         // 无上下文，会因注册更晚而抢走弹窗/设置页输入框的 Ctrl+V。
         KeyBinding::new("ctrl-v", PasteClipboard, Some(crate::gpui_shell::terminal::KEY_CONTEXT)),
@@ -282,7 +296,8 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("ctrl-shift-v", gpui_component::input::Paste, Some("Input")),
         KeyBinding::new("alt-enter", ToggleFullscreen, None),
         KeyBinding::new("ctrl-shift-o", OpenQuickJump, None),
-    ]);
+    ]
+    .into()
 }
 
 /// 一个终端 pane：视图实体 + 宿主订阅。id 即 `TerminalView::pane_id`

--- a/nebula_app/src/gpui_shell/workspace/tests.rs
+++ b/nebula_app/src/gpui_shell/workspace/tests.rs
@@ -262,6 +262,45 @@ fn paste_keymap_keeps_component_inputs_and_terminals_in_separate_contexts() {
     assert!(bindings[0].action().as_any().is::<PasteClipboard>());
 }
 
+/// 复制与粘贴同型分流：ctrl-c 在终端上下文命中 CopySelection（有选区复制、
+/// 无选区经 handler propagate 落成 ^C），在输入框上下文命中 Input 自己的 Copy——
+/// 重命名/设置页输入框的 ctrl-c 复制框内文本，不会拷终端选区。
+#[test]
+fn copy_keymap_keeps_component_inputs_and_terminals_in_separate_contexts() {
+    use gpui::{KeyContext, Keymap, Keystroke};
+
+    let keymap = Keymap::new(vec![
+        KeyBinding::new("ctrl-c", CopySelection, Some(crate::gpui_shell::terminal::KEY_CONTEXT)),
+        KeyBinding::new("ctrl-c", gpui_component::input::Copy, Some("Input")),
+    ]);
+    let key = [Keystroke::parse("ctrl-c").unwrap()];
+
+    let input = [KeyContext::parse("Root").unwrap(), KeyContext::parse("Input").unwrap()];
+    let (bindings, pending) = keymap.bindings_for_input(&key, &input);
+    assert!(!pending);
+    assert_eq!(bindings.len(), 1);
+    assert!(bindings[0].action().as_any().is::<gpui_component::input::Copy>());
+
+    let terminal = [
+        KeyContext::parse("Root").unwrap(),
+        KeyContext::parse(crate::gpui_shell::terminal::KEY_CONTEXT).unwrap(),
+    ];
+    let (bindings, pending) = keymap.bindings_for_input(&key, &terminal);
+    assert!(!pending);
+    assert_eq!(bindings.len(), 1);
+    assert!(bindings[0].action().as_any().is::<CopySelection>());
+
+    // 默认表与镜像清单同步：ctrl-c 必须真的注册在默认绑定里。
+    let bindings = default_workspace_bindings();
+    let Some(binding) = bindings.iter().find(|b| {
+        b.keystrokes().first().is_some_and(|ks| ks.inner() == &Keystroke::parse("ctrl-c").unwrap())
+    }) else {
+        panic!("ctrl-c 缺省必须绑到 CopySelection");
+    };
+    assert!(binding.action().name().ends_with("CopySelection"), "ctrl-c 应映射到 CopySelection");
+    assert!(STATIC_DEFAULT_COMBOS.contains(&"ctrl-c"), "静态默认键清单也要同步增 ctrl-c");
+}
+
 #[test]
 fn pane_card_divider_reaches_the_window_top_without_moving_its_bottom() {
     let card = Bounds::new(gpui::point(px(230.0), px(48.0)), size(px(850.0), px(672.0)));


### PR DESCRIPTION
## Problem

The GPUI shell has no default `ctrl-c` binding (only `ctrl-shift-c`). With copy-on-select off, pressing Ctrl+C after selecting text never reaches the clipboard — the key always goes to the PTY as `^C`, so nothing is copied.

## Fix

Add a `ctrl-c` default binding for the existing `CopySelection` action, scoped to the terminal key context (`NebulaTerminal`) introduced for paste in 1.5.0:

- **Selection present**: copy and clear the selection (existing `CopySelection` semantics).
- **No selection**: the handler propagates, so the encoder still emits `^C` and the PTY receives SIGINT — Windows Terminal semantics.
- **Rename / settings input focused**: the binding does not fire outside the terminal context, so the field's own Ctrl+C (Input → Copy) keeps working. No focus-guard needed.

Custom `keybind=ctrl+c:Copy`-style user bindings (`Action::Copy`) get the same terminal context, mirroring what 1.5.0 does for `Action::Paste`.

`ctrl-shift-c` behavior is unchanged.

## Tests

- New Keymap unit test: in the terminal context, `ctrl-c` resolves to `CopySelection`; in the `Input` context it resolves to the component's Copy. Also asserts the default table contains the binding and `STATIC_DEFAULT_COMBOS` stays in sync.
