### PR TITLE
feat(gpui): terminal network proxy toggle for new sessions

### DIFF
--- a/nebula_app/src/gpui_shell/network_settings.rs
+++ b/nebula_app/src/gpui_shell/network_settings.rs
@@ -159,6 +159,13 @@ impl SettingsPane {
             .child(div().h(px(PROXY_TEST_GAP)).w_full().flex_shrink_0())
             .child(self.proxy_mode_row(cx))
             .when(custom, |page| page.child(self.proxy_address_row(cx)))
+            .child(self.switch_row(
+                "terminal_proxy",
+                "系统代理",
+                "启用时，新建终端的 HTTP(S)_PROXY 会接入系统代理。",
+                self.runtime.terminal_proxy,
+                cx,
+            ))
     }
 
     fn proxy_test_banner(&self, cx: &mut Context<Self>) -> gpui::Div {

--- a/nebula_app/src/gpui_shell/settings_pane.rs
+++ b/nebula_app/src/gpui_shell/settings_pane.rs
@@ -2087,6 +2087,7 @@ impl SettingsPane {
             "copy_on_select" => flag!(copy_on_select),
             "multiline_paste_confirm" => flag!(multiline_paste_confirm),
             "tab_close_visible" => flag!(tab_close_visible),
+            "terminal_proxy" => flag!(terminal_proxy),
             "powerline" => flag!(powerline),
             "ghost" => flag!(ghost),
             "cjk_bold_regular" => flag!(cjk_bold_regular),
@@ -2122,7 +2123,8 @@ impl SettingsPane {
         }
     }
 
-    fn switch_row(
+    /// 斗隔 union 里 network_settings.rs 也用它。
+    pub(super) fn switch_row(
         &self,
         key: &'static str,
         label: &'static str,

--- a/nebula_app/src/gpui_shell/terminal/session.rs
+++ b/nebula_app/src/gpui_shell/terminal/session.rs
@@ -91,6 +91,16 @@ pub(super) fn local_options(
     if let Err(error) = tty::refresh_environment(&mut options) {
         log::warn!("Could not refresh the Windows environment for a new pane: {error}");
     }
+    // 终端网络代理开启时，把当前系统代理同步给新会话（HTTP(S)_PROXY 变量），
+    // 让会话里的 curl/git/npm 等不必重复设。系统代理探不到则什么都不做。
+    // 放在环境重建之后：注入值作为 pane 专属覆盖，不被注册表快照冲掉。
+    #[cfg(windows)]
+    if ::nebula_settings::RuntimeSettings::load().terminal_proxy
+        && let Some((url, _)) = crate::ssh_proxy::probe_system_proxy()
+    {
+        options.env.insert("HTTP_PROXY".into(), url.clone());
+        options.env.insert("HTTPS_PROXY".into(), url);
+    }
     // WSL tab 的命令边界（OSC 133;D/A）与 cwd（OSC 7）：来宾登录 shell 默认
     // 不发，Agent 生命周期、目录树与 Git 视图都会失去来宾侧事实。只对
     // `wsl.exe` 启动生效，见 [`crate::shell_detect::wsl_cwd_report_env`]。

--- a/nebula_settings/src/lib.rs
+++ b/nebula_settings/src/lib.rs
@@ -957,6 +957,9 @@ pub struct RuntimeSettings {
     pub multiline_paste_confirm: bool,
     /// 标签页关闭按钮（叉号）是否渲染：关 = 不渲染，仍可用中键关闭。
     pub tab_close_visible: bool,
+    /// 终端网络代理：新会话启动时把当前系统代理写入 HTTP_PROXY/HTTPS_PROXY。
+    /// 上游默认关 (false) —— fork 侧另起本地 commit 翻成默认开。
+    pub terminal_proxy: bool,
     pub powerline: bool,
     /// 默认 shell 的原始 id（`shell=` 原文：powershell/bash/cmd/pwsh/WSL
     /// 发行版等）。解析归 shell 检测层，这里只做持久化往返。
@@ -1093,6 +1096,7 @@ impl RuntimeSettings {
             copy_on_select: raw.bool_on("copy_on_select").unwrap_or(false),
             multiline_paste_confirm: raw.bool_on("multiline_paste_confirm").unwrap_or(true),
             tab_close_visible: raw.bool_on("tab_close_visible").unwrap_or(true),
+            terminal_proxy: raw.bool_on("terminal_proxy").unwrap_or(false),
             powerline: raw.bool_on("powerline").unwrap_or(true),
             shell: raw.value("shell").or_else(|| raw.value("executor")).map(str::to_owned),
             startup_directory: raw.value("startup_directory").map(str::to_owned),
@@ -1340,6 +1344,7 @@ mod tests {
         assert!(!settings.copy_on_select);
         assert!(settings.multiline_paste_confirm, "多行粘贴确认默认开（上游兼容）");
         assert!(settings.tab_close_visible, "标签关闭按钮默认可见（上游兼容）");
+        assert!(!settings.terminal_proxy, "终端网络代理上游默认关（兼容）");
         assert!(settings.powerline);
         assert!(settings.ghost);
         assert_eq!(settings.accept, AcceptKeyName::Both);


### PR DESCRIPTION
## Problem

Tools inside new terminal sessions (curl, git, npm, …) do not see the Windows system proxy; users have to export `HTTP_PROXY`/`HTTPS_PROXY` by hand in every session.

## Feature

New **Network → System proxy** toggle (off by default, purely additive — fully backward compatible). When enabled, each new local session inherits the proxy detected from Windows system settings into `HTTP_PROXY`/`HTTPS_PROXY`:

- The panel reuses the existing `ssh_proxy::probe_system_proxy()` (follows the live Windows system proxy; no hardcoded address). If no system proxy is found, nothing is injected.
- The injection happens after the per-pane environment rebuild (#68), as a pane-specific override, so it survives the registry snapshot merge.
- SSH egress proxy settings are unaffected — this only seeds the PTY environment.

A settings-page test asserts the upstream default stays off; a fork integration branch may flip the default on locally, but that commit is not part of this PR.

## Tests

- Settings default-off unit test.
- Existing proxy/SSH suites keep passing.
