### PR TITLE
fix(gpui): support Shift+Enter newline and antigravity-cli idle detection

### DIFF
--- a/nebula_app/src/agent_detection/antigravity.toml
+++ b/nebula_app/src/agent_detection/antigravity.toml
@@ -5,24 +5,67 @@ aliases = ["agy", "antigravity-cli"]
 [[rules]]
 id = "permission_prompt"
 state = "blocked"
-priority = 300
-region = "whole_recent"
-contains = ["requesting permission for:"]
+priority = 900
+region = "bottom_non_empty_lines(12)"
 any = [
-  { contains = ["do you want to proceed?"] },
+  { contains = ["requesting approval"], any = [
+    { contains = ["[y]"] },
+    { contains = ["(y/n)"] },
+    { contains = ["[y/n]"] },
+    { contains = ["always allow"] },
+    { contains = ["esc to cancel"] },
+    { contains = ["enter to confirm"] },
+  ]},
+  { contains = ["needs approval"], any = [
+    { contains = ["[y]"] },
+    { contains = ["(y/n)"] },
+    { contains = ["[y/n]"] },
+    { contains = ["always allow"] },
+    { contains = ["esc to cancel"] },
+    { contains = ["enter to confirm"] },
+  ]},
+  { contains = ["requesting permission"], any = [
+    { contains = ["[y]"] },
+    { contains = ["(y/n)"] },
+    { contains = ["[y/n]"] },
+    { contains = ["always allow"] },
+    { contains = ["esc to cancel"] },
+    { contains = ["enter to confirm"] },
+  ]},
   { contains = ["tab amend", "edit command"] },
+  { contains = ["tab to amend"] },
 ]
 
 [[rules]]
 id = "spinner_working"
 state = "working"
-priority = 100
-region = "whole_recent"
+priority = 400
+region = "bottom_non_empty_lines(8)"
 line_regex = ['^\s*[\u2800-\u28FF]+\s+\p{Alphabetic}+\w*ing\b']
 
 [[rules]]
 id = "background_tasks_working"
 state = "working"
-priority = 90
+priority = 380
 region = "bottom_non_empty_lines(5)"
 line_regex = ['(?i)·\s*[1-9][0-9]*\s+task']
+
+[[rules]]
+id = "prompt_idle"
+state = "idle"
+priority = 100
+region = "bottom_non_empty_lines(6)"
+any = [
+  { contains = ["shift+tab to cycle"] },
+  { contains = ["? for shortcuts"] },
+  { line_regex = ['^\s*[›❯>](?:\s|$)'] },
+]
+not = [
+  { contains = ["esc to interrupt"] },
+  { contains = ["esc to cancel"] },
+  { contains = ["requesting approval"], any = [{ contains = ["[y]"] }, { contains = ["(y/n)"] }, { contains = ["[y/n]"] }, { contains = ["always allow"] }] },
+  { contains = ["needs approval"], any = [{ contains = ["[y]"] }, { contains = ["(y/n)"] }, { contains = ["[y/n]"] }, { contains = ["always allow"] }] },
+  { contains = ["requesting permission"], any = [{ contains = ["[y]"] }, { contains = ["(y/n)"] }, { contains = ["[y/n]"] }, { contains = ["always allow"] }] },
+]
+
+

--- a/nebula_app/src/ai_agents.rs
+++ b/nebula_app/src/ai_agents.rs
@@ -920,4 +920,80 @@ mod tests {
             assert_eq!(found.status, AgentStatus::Blocked, "{agent} rule={}", found.rule_id);
         }
     }
+
+    #[test]
+    fn real_antigravity_working_chrome_reads_working() {
+        let screen = "  ⠋ Thinking... (8s)\n\
+                      ────────────────────────────────────────\n\
+                      › \n\
+                      ────────────────────────────────────────\n\
+                      \x20 Plan mode: research & plan only (shift+tab to cycle) · Press esc to interrupt generation";
+        let detection = detect("antigravity", screen).unwrap();
+        assert_eq!(detection.status, AgentStatus::Working, "rule={}", detection.rule_id);
+    }
+
+    #[test]
+    fn real_antigravity_idle_chrome_reads_idle() {
+        let screen = "  I have completed the task and updated the configuration.\n\
+                      ────────────────────────────────────────\n\
+                      › \n\
+                      ────────────────────────────────────────\n\
+                      \x20 Plan mode: research & plan only (shift+tab to cycle) · ? for shortcuts";
+        let detection = detect("antigravity", screen).unwrap();
+        assert_eq!(detection.status, AgentStatus::Idle, "rule={}", detection.rule_id);
+    }
+
+    #[test]
+    fn antigravity_old_scrollback_spinner_does_not_prevent_idle() {
+        // 历史滚屏中留有上一轮的思考转圈符号；region 限制在底部后不能把已结束的回合误判为 Working。
+        let screen = "  ⠋ Thinking... (from previous turn 5m ago)\n\
+                      \x20 Result: success\n\
+                      \x20 Line 1\n\
+                      \x20 Line 2\n\
+                      \x20 Line 3\n\
+                      \x20 Line 4\n\
+                      \x20 Line 5\n\
+                      \x20 Line 6\n\
+                      \x20 Line 7\n\
+                      \x20 Line 8\n\
+                      \x20 Line 9\n\
+                      \x20 Line 10\n\
+                      ────────────────────────────────────────\n\
+                      › \n\
+                      ────────────────────────────────────────\n\
+                      \x20 Accept-edits mode: file edits auto-approved (shift+tab to cycle)";
+        let detection = detect("antigravity", screen).unwrap();
+        assert_eq!(detection.status, AgentStatus::Idle, "rule={}", detection.rule_id);
+    }
+
+    #[test]
+    fn real_antigravity_permission_form_reads_blocked() {
+        let screen = " requesting permission for:\n\
+                      \x20 Run command: cargo test\n\
+                      \x20 Do you want to proceed?\n\
+                      \x20 › 1. Yes, allow\n\
+                      \x20   2. No, deny access\n\
+                      \x20 esc to cancel · tab amend";
+        let detection = detect("antigravity", screen).unwrap();
+        assert_eq!(detection.status, AgentStatus::Blocked, "rule={}", detection.rule_id);
+    }
+
+    #[test]
+    fn antigravity_prose_mentioning_approval_while_idle_reads_idle() {
+        // 回答正文中提及 "needs approval for ..."，但此时已完成并显示空闲提示符，
+        // 不得误判为 Blocked。
+        for phrase in ["needs approval for", "requesting approval for", "requesting permission for:"] {
+            let screen = format!(
+                "│ The tool {phrase} operations outside the workspace.\n\
+                 │ Please confirm your settings if you plan to enable this.\n\
+                 ────────────────────────────────────────\n\
+                 › \n\
+                 ────────────────────────────────────────\n\
+                 \x20 Plan mode: research & plan only (shift+tab to cycle) · ? for shortcuts"
+            );
+            let detection = detect("antigravity", &screen).unwrap();
+            assert_eq!(detection.status, AgentStatus::Idle, "{phrase}: rule={}", detection.rule_id);
+        }
+    }
 }
+

--- a/nebula_app/src/gpui_shell/terminal/keymap.rs
+++ b/nebula_app/src/gpui_shell/terminal/keymap.rs
@@ -165,8 +165,18 @@ fn virtual_key_of(key: &str) -> Option<u16> {
 /// Tab=0x09、Backspace=0x08）：OpenConsole 1.22 的 VT 翻译层会丢弃 uChar=0
 /// 的 VK_ESCAPE，于是读字节流的那类应用（Claude Code）收不到 Esc。修饰键与
 /// 功能键保持 0，与真实键盘一致。逐条同旧壳 `control_char_fallback`。
+///
+/// Shift+Enter 在支持的终端应用中语义为换行（uChar=0x0A / 10）。
+/// 普通 Enter 保持 0x0D（CR），让子进程如常执行回车提交。
 #[cfg(windows)]
 fn unicode_char_of(ks: &Keystroke) -> u16 {
+    if ks.key.as_str() == "enter" {
+        return if ks.modifiers.shift && !ks.modifiers.control && !ks.modifiers.alt {
+            b'\n' as u16
+        } else {
+            b'\r' as u16
+        };
+    }
     // 平台已经判出文本的（含 Ctrl 变体）以它为准，与 WM_CHAR 语义一致。
     // `key_char` 若是 NUL，当作没文本：真实键盘的 Esc 不会写出 U+0000。
     if let Some(text) = ks.key_char.as_deref() {
@@ -179,7 +189,6 @@ fn unicode_char_of(ks: &Keystroke) -> u16 {
     }
     match ks.key.as_str() {
         "escape" => 0x1b,
-        "enter" => b'\r' as u16,
         "tab" => b'\t' as u16,
         // 真实控制台的 Ctrl+Backspace 记录携带 Uc=DEL（0x7f，WM_CHAR 语义），
         // PSReadLine 的原生 Ctrl+Backspace=BackwardKillWord 绑定按此匹配。
@@ -287,6 +296,14 @@ pub fn encode(ks: &Keystroke, mode: &TermMode) -> Option<Vec<u8>> {
 
     match ks.key.as_str() {
         "enter" => {
+            // Kitty 模式下 Shift+Enter 编码为 CSI 13;2u，避免修饰丢失变成普通回车；
+            // 启用 REPORT_ALL_KEYS_AS_ESC 且无修饰时出 CSI 13u。
+            if kitty_keyboard_active(mode) && ks.modifiers.shift && !ks.modifiers.control && !ks.modifiers.alt {
+                return Some(b"\x1b[13;2u".to_vec());
+            }
+            if mode.contains(TermMode::REPORT_ALL_KEYS_AS_ESC) && modifier_param(ks) == 1 {
+                return Some(b"\x1b[13u".to_vec());
+            }
             return Some(if mods.alt { b"\x1b\r".to_vec() } else { b"\r".to_vec() });
         },
         "backspace" => {
@@ -510,5 +527,62 @@ mod tests {
         assert_eq!(encode(&keystroke("backspace"), &mode), Some(b"\x7f".to_vec()));
         let kitty = TermMode::DISAMBIGUATE_ESC_CODES;
         assert_eq!(encode(&keystroke("backspace"), &kitty), Some(b"\x7f".to_vec()));
+    }
+
+    /// 传统 VT 路径：Enter 提交（\r），Alt+Enter 带 ESC 前缀（\x1b\r）。
+    #[test]
+    fn enter_emits_cr_in_legacy_vt() {
+        let mode = TermMode::default();
+        let mut ks = keystroke("enter");
+        assert_eq!(encode(&ks, &mode), Some(b"\r".to_vec()));
+        ks.modifiers.shift = true;
+        assert_eq!(encode(&ks, &mode), Some(b"\r".to_vec()));
+        ks.modifiers.shift = false;
+        ks.modifiers.control = true;
+        assert_eq!(encode(&ks, &mode), Some(b"\r".to_vec()));
+
+        let mut alt_enter = keystroke("enter");
+        alt_enter.modifiers.alt = true;
+        assert_eq!(encode(&alt_enter, &mode), Some(b"\x1b\r".to_vec()));
+        alt_enter.modifiers.shift = true;
+        assert_eq!(encode(&alt_enter, &mode), Some(b"\x1b\r".to_vec()));
+    }
+
+    /// kitty 协议下，Shift+Enter 编码为 CSI 13;2u，避免修饰丢失变成普通回车；
+    /// 仅 REPORT_ALL_KEYS_AS_ESC 下无修饰 Enter 编码为 CSI 13u。
+    #[test]
+    fn enter_emits_kitty_u_sequence_when_modified() {
+        let mode = TermMode::DISAMBIGUATE_ESC_CODES;
+        let mut ks = keystroke("enter");
+        // DISAMBIGUATE_ESC_CODES 下裸回车不转义，回落为 \r
+        assert_eq!(encode(&ks, &mode), Some(b"\r".to_vec()));
+
+        ks.modifiers.shift = true;
+        assert_eq!(encode(&ks, &mode), Some(b"\x1b[13;2u".to_vec()));
+
+        // REPORT_ALL_KEYS_AS_ESC 下裸回车也是 CSI 13u
+        let all_keys_mode = TermMode::REPORT_ALL_KEYS_AS_ESC;
+        let bare = keystroke("enter");
+        assert_eq!(encode(&bare, &all_keys_mode), Some(b"\x1b[13u".to_vec()));
+    }
+
+    /// Win32 input mode 下，Shift+Enter 携带 uChar=10（\n），裸 Enter 携带 uChar=13（\r）。
+    #[cfg(windows)]
+    #[test]
+    fn enter_win32_record_carries_newline_for_shift() {
+        let mode = TermMode::WIN32_INPUT_MODE;
+        let parse_record = |bytes: Vec<u8>| -> (String, String) {
+            let text = String::from_utf8(bytes).unwrap();
+            let first_record = text.split('_').next().unwrap();
+            let fields: Vec<&str> = first_record.strip_prefix("\x1b[").unwrap().split(';').collect();
+            (fields[0].to_owned(), fields[2].to_owned())
+        };
+
+        let bare = keystroke("enter");
+        assert_eq!(parse_record(encode(&bare, &mode).unwrap()), ("13".to_string(), "13".to_string()));
+
+        let mut shift_enter = keystroke("enter");
+        shift_enter.modifiers.shift = true;
+        assert_eq!(parse_record(encode(&shift_enter, &mode).unwrap()), ("13".to_string(), "10".to_string()));
     }
 }

--- a/nebula_app/src/gpui_shell/terminal/view.rs
+++ b/nebula_app/src/gpui_shell/terminal/view.rs
@@ -1928,7 +1928,22 @@ impl TerminalView {
         let mods = &ks.modifiers;
         let plain_mods = !mods.control && !mods.alt && !mods.platform;
         match ks.key.as_str() {
-            "enter" => self.commit_line(cx),
+            "enter" => {
+                // 与 keymap 的 Shift+Enter 分流一致；传统 VT 仍发送 CR 并提交。
+                let is_negotiated_multiline = mods.shift
+                    && !mods.control
+                    && !mods.alt
+                    && (mode.intersects(
+                        TermMode::DISAMBIGUATE_ESC_CODES
+                            | TermMode::REPORT_ALL_KEYS_AS_ESC
+                            | TermMode::REPORT_EVENT_TYPES,
+                    ) || (cfg!(windows)
+                        && mode.contains(TermMode::WIN32_INPUT_MODE)
+                        && !mode.intersects(TermMode::KITTY_KEYBOARD_PROTOCOL)));
+                if !is_negotiated_multiline {
+                    self.commit_line(cx);
+                }
+            },
             "backspace" if mods.control && !mods.alt && !mods.platform => {
                 crate::display::nebula_input_delete_word(&mut self.suggest);
             },


### PR DESCRIPTION
Fixes #95

## Problem

When using `antigravity-cli` (and other terminal applications/agents) inside Nebula:
1. **Shift+Enter does not insert a newline**:
   - In Win32 input mode (`DECSET 9001`), `Shift+Enter` was emitted with `uChar = 0x0D` (`\r`), matching bare Enter and immediately submitting the prompt rather than inserting a newline (`\n` / `uChar = 10`).
   - In Kitty keyboard protocol mode, `Shift+Enter` lacked a specific CSI u mapping, causing modified Enter to degrade to bare Enter submission.
   - In `TerminalView`, pressing `Enter` always called `self.commit_line(cx)` unconditionally, recording command history and resetting prompt state even when an application negotiated multiline mode.
2. **Conversation completion / idle state is not detected**:
   - `antigravity.toml` only defined `spinner_working` and a loose `permission_prompt`. When `antigravity-cli` finished generating responses and returned to prompt input (`› ...`, `shift+tab to cycle`), Nebula continued displaying the "working" spinner indefinitely.
   - Furthermore, `permission_prompt` could falsely trigger `Blocked` on normal prose output containing phrases like "needs approval".

## Fix

1. **Shift+Enter Newline Handling**:
   - **Win32 Input Mode**: For `Shift+Enter` (without Ctrl/Alt), `unicode_char_of` now emits `uChar = b'\n' as u16` (`10`), matching standard Windows console line-continuation behavior, while bare Enter keeps `0x0D` (`\r`).
   - **Kitty Keyboard Protocol**: `kitty_sequence` maps `Shift+Enter` to `\x1b[13;2u` (CSI 13;2u), preserving the Shift modifier for terminal editors.
   - **Legacy VT Mode**: Preserves standard `\r` (or `\x1b\r` for Alt) so non-negotiated shell workflows continue executing commands normally.
   - **Terminal View Input Tracking**: `commit_line` is skipped strictly when `Shift+Enter` is pressed under negotiated multiline protocols (Kitty / Win32 input mode), avoiding false command execution tracking while preserving full tracking in legacy shells.

2. **Antigravity Agent Status Detection**:
   - Added `prompt_idle` rule in `antigravity.toml` detecting the bottom input prompt (`[›❯>]`) and help hints (`shift+tab to cycle`, `? for shortcuts`), with negative assertions against interrupt/approval prompts.
   - Tightened `permission_prompt` to require interactive confirmation tokens (`[y]`, `(y/n)`, `[y/n]`, `always allow`, etc.) alongside approval phrases, preventing false positives from plain conversational text.
   - Scoped `spinner_working` to recent non-empty lines (`bottom_non_empty_lines(8)`).

## Tests

- Added unit tests in `nebula_app/src/gpui_shell/terminal/keymap.rs` covering:
  - Legacy VT path emitting `\r` (and `\x1b\r` for Alt)
  - Kitty protocol emitting `\x1b[13;2u` for Shift+Enter and `\x1b[13u` under `REPORT_ALL_KEYS_AS_ESC`
  - Win32 input mode record carrying `uChar = 10` for Shift+Enter vs `uChar = 13` for bare Enter
- Added unit tests in `nebula_app/src/ai_agents.rs` verifying `antigravity-cli` agent states:
  - Working spinner detection
  - Idle prompt recognition
  - Permission approval dialog classification (`Blocked`)
  - Stale scrollback spinner exclusion
  - Conversational approval mentions while idle classification (`Idle`)
- Full test suite passing (`cargo test -p nebula --bin nebula --features gpui-shell`: 944 passed).
