### PR TITLE
fix(shell): resolve the real default shell instead of a hard-coded powershell

### DIFF
--- a/nebula_app/src/gpui_shell/settings_pane.rs
+++ b/nebula_app/src/gpui_shell/settings_pane.rs
@@ -530,7 +530,7 @@ impl SettingsPane {
 
     /// 按当前设置值重建下拉候选（导入后新增行即时可见）。
     fn refresh_shell_items(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let current = self.runtime.shell.clone().unwrap_or_else(|| "powershell".into());
+        let current = crate::platform::shell::effective_shell_id(self.runtime.shell.as_deref());
         let (items, selected) = shell_select_items(
             &current,
             window.scale_factor().max(0.5),
@@ -544,7 +544,7 @@ impl SettingsPane {
 
     /// 把下拉选中项拨回设置里真正生效的 shell。
     fn restore_shell_selection(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let current = self.runtime.shell.clone().unwrap_or_else(|| "powershell".into());
+        let current = crate::platform::shell::effective_shell_id(self.runtime.shell.as_deref());
         self.shell_select.update(cx, |state, cx| {
             state.set_selected_value(&current, window, cx);
         });

--- a/nebula_app/src/gpui_shell/settings_pane/initialization.rs
+++ b/nebula_app/src/gpui_shell/settings_pane/initialization.rs
@@ -46,7 +46,7 @@ impl SettingsPane {
 
         let cursor_current =
             runtime.cursor_shape.map(|shape| shape.settings_value()).unwrap_or("beam");
-        let shell_current = runtime.shell.clone().unwrap_or_else(|| "powershell".into());
+        let shell_current = crate::platform::shell::effective_shell_id(runtime.shell.as_deref());
 
         add_select(
             "language",

--- a/nebula_app/src/gpui_shell/settings_pane/shell_picker.rs
+++ b/nebula_app/src/gpui_shell/settings_pane/shell_picker.rs
@@ -75,12 +75,15 @@ pub(super) fn shell_select_items(
         .map(|shell| ShellSelectItem::new(shell.id, shell.name, scale_factor))
         .collect();
     if items.is_empty() {
-        // 非 Windows 构建不做安装探测，但历史配置仍支持这两个由 PTY
-        // 集成层负责启动的稳定 id，设置页不能因此变成空下拉。
-        items = vec![
-            ShellSelectItem::new("powershell".into(), "PowerShell".into(), scale_factor),
-            ShellSelectItem::new("bash".into(), "Git Bash".into(), scale_factor),
-        ];
+        // 探测不到任何已安装 shell 时也要给出一行——用宿主默认 id，而不是
+        // 写死的 PowerShell/Git Bash：没有安装探测结果的 Unix 机器（例如
+        // `$SHELL` 与 `/etc/shells` 都读不到）默认是登录 shell，不是 PS。
+        let id = crate::platform::shell::default_shell_id();
+        items = vec![ShellSelectItem::new(
+            id.clone(),
+            crate::shell_detect::display_name_for_id(&id),
+            scale_factor,
+        )];
     }
     // 导入的终端目录：`merge_terminal_profiles` 已把它们并进配置的 profile
     // 列表，这里让设置页也能直接选为默认 Shell——否则导入完看不见结果。

--- a/nebula_app/src/gpui_shell/workspace.rs
+++ b/nebula_app/src/gpui_shell/workspace.rs
@@ -3194,10 +3194,10 @@ impl NebulaWorkspace {
     /// 三点 / Ctrl+K：旧壳 `NewTabMenu` → `open_shell_menu` → `PaletteMode::Profiles`。
     fn open_shell_palette(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.command_manager_open = false;
-        let default_shell_id = cx
-            .try_global::<crate::gpui_shell::config::Settings>()
-            .and_then(|settings| settings.shell_id.clone())
-            .unwrap_or_else(|| "powershell".to_owned());
+        let default_shell_id = crate::platform::shell::effective_shell_id(
+            cx.try_global::<crate::gpui_shell::config::Settings>()
+                .and_then(|settings| settings.shell_id.as_deref()),
+        );
         let language = workspace_ui_language();
         let rows = shell_palette_rows(
             crate::shell_detect::detect_shells(),

--- a/nebula_app/src/platform/shell.rs
+++ b/nebula_app/src/platform/shell.rs
@@ -26,6 +26,21 @@ pub fn default_shell_id() -> String {
     }
 }
 
+/// The shell id a picker or label should treat as current: the configured
+/// value when it names anything, otherwise the host's own default. An empty or
+/// whitespace-only value is "unset", not a shell named `""`.
+///
+/// Every GPUI surface that shows a "default shell" must go through this —
+/// falling back to a hard-coded `powershell` made a Mac with no saved `shell=`
+/// display and recommend PowerShell instead of its login shell.
+pub fn effective_shell_id(configured: Option<&str>) -> String {
+    configured
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_owned)
+        .unwrap_or_else(default_shell_id)
+}
+
 pub fn interactive_args(id: &str) -> Vec<String> {
     if cfg!(target_os = "macos") && matches!(id, "zsh" | "bash" | "fish") {
         vec!["-l".to_owned()]
@@ -82,6 +97,23 @@ mod tests {
     #[test]
     fn default_shell_id_is_never_empty() {
         assert!(!default_shell_id().is_empty());
+    }
+
+    /// 未保存 `shell=` 时必须落到宿主默认，而不是某个硬编码 id。回归锁：
+    /// 设置页「默认 Shell」和新终端选择弹窗此前都硬编码回落到 `powershell`，
+    /// 于是没存过 `shell=` 的 Mac 上显示并推荐的是 PowerShell 而不是登录 shell。
+    #[test]
+    fn effective_shell_id_falls_back_to_the_host_default() {
+        let host = default_shell_id();
+        for configured in [None, Some(""), Some("   ")] {
+            assert_eq!(
+                effective_shell_id(configured),
+                host,
+                "未设置的值必须解析成宿主默认，不能是硬编码 id"
+            );
+        }
+        assert_eq!(effective_shell_id(Some(" bash ")), "bash");
+        assert_eq!(effective_shell_id(Some("pwsh")), "pwsh");
     }
 
     #[test]


### PR DESCRIPTION
## Result / 用户结果

Settings → 终端 的「默认 Shell」下拉，以及三点 / Ctrl+K 打开的新终端弹窗，在没存过 `shell=` 时会回落成写死的 `powershell`：macOS 上显示并推荐的是 Windows PowerShell 的 id，而真实默认是登录 shell（zsh）。

现在四个入口统一走一个权威 `platform::shell::effective_shell_id` —— 有配置值用配置值，空 / 空白 / 未设置才解析宿主默认（macOS 上是 `zsh`）。

无关联 issue：本地实测发现。

## Design / 设计边界

- **Responsibility and affected modules:** 唯一权威在 `nebula_app/src/platform/shell.rs`（新增 `effective_shell_id`）。调用点：`gpui_shell/settings_pane.rs`（重建候选、恢复选中）、`gpui_shell/settings_pane/initialization.rs`（下拉初始值）、`gpui_shell/workspace.rs`（新终端弹窗的「推荐」置顶）、`gpui_shell/settings_pane/shell_picker.rs`（空探测回落）。
- **Why this belongs here; interfaces that remain unchanged:** `platform::shell` 本来就是「宿主相关 shell 默认值」的归属地，模块文档写明它的职责是防止标签/持久化 id 与 PTY 实际默认值漂移。`default_shell_id()`、`shell=<id>` 持久化语义、PTY 启动路径都不变。
- **Dependency, data-format, threading, or lifetime changes:** 无。
- **Compatibility and migration/fallback behavior:** 显式 `shell=<id>` 原样保留；仅空 / 空白 / `None` 回落到宿主默认。`shell_picker` 的「探测不到任何已安装 shell」回落从写死 PowerShell/Git Bash 改成宿主默认 id。

## Evidence / 验证依据

- 命令与结果：`cargo test --locked -p nebula --bin pebrel --features gpui-shell,gpui_platform/runtime_shaders,gpui-test-support -- platform::shell` → **5 passed / 0 failed**。
- Regression: `effective_shell_id_falls_back_to_the_host_default` —— `None`、`""`、纯空白都必须等于 `default_shell_id()`；`" bash "` → `"bash"`，`"pwsh"` → `"pwsh"`。修复前没有这个函数，四处各自硬编码，测试无从表达。
- 未运行：`python3 scripts/check_architecture.py --base c2deb16` —— 本机只有 Python 3.9.6，检查器要求 3.11+（`import tomllib` 失败）。已人工确认改动文件均低于配额、未新增或修改依赖边。
- 仅验证 macOS 构建；`#[cfg(windows)]` 分支未改，也未在 Windows 上运行。
- 未做打包应用验证。

## Required Review / 必须确认

- [x] 已遵循 `CONTRIBUTING.md`、`docs/architecture.md`、`docs/project-constraints.md`。
- [x] 按职责拆分，未新增重复的行为权威。
- [x] `scripts/check_architecture.py` 未能运行（环境缺 Python 3.11+，见上）；未抬高任何预算。
- [x] 有回归测试；平台覆盖限制已说明。
- [x] 无新增 UI 文案。
- [x] 无治理变更。

*与另外两个 PR（shell 图标尺寸、通知溢出）无文件冲突：同文件的改动落在不同区域，任意顺序合并均可。*
