### PR TITLE
fix(shell): one same-sized marker per shell, and space the picker rows

### DIFF
--- a/nebula_app/src/gpui_shell/settings_pane/shell_picker.rs
+++ b/nebula_app/src/gpui_shell/settings_pane/shell_picker.rs
@@ -15,6 +15,21 @@ pub(super) struct ShellSelectItem {
 /// `wsl:<distro>`、`profile:<家族>|<id>`），双下划线包裹不可能与之相撞。
 pub(super) const SHELL_IMPORT_ACTION_ID: &str = "__nebula_import_terminal_dir__";
 
+/// 菜单行的逻辑边长（品牌贴图与图标槽同用）。
+pub(super) const SHELL_ROW_ICON_SIZE: f32 = 24.0;
+
+/// 回落字形的字号系数：见 `shell_detect::FALLBACK_ICON_SCALE`。
+const FALLBACK_ICON_SCALE: f32 = crate::shell_detect::FALLBACK_ICON_SCALE;
+
+/// 真实 shell 行之间的垂直间距。
+///
+/// `gpui-component` 的虚拟列表不支持条目 `gap_y`（`list.rs` 里明确写了），
+/// 每行背景按同一槽高首尾相接。可用的唯一着力点：它只量**首行**的槽高再拿
+/// 这个高度排所有行。给置顶的「导入终端目录」动作行加一段下内边距，槽高就
+/// 比普通行多出这一段，余下每一行之间便空出同样的间隔；动作行自身也在文字
+/// 下方留出这段空白，选中高亮不再贴着它。
+pub(super) const SHELL_ROW_GAP: f32 = 4.0;
+
 impl ShellSelectItem {
     pub(super) fn new(id: String, name: String, scale_factor: f32) -> Self {
         // Select 的闭态和菜单行尺寸不同。分别生成与物理像素一一对应的纹理，
@@ -47,15 +62,36 @@ impl ShellSelectItem {
             .into_any_element()
         } else if self.is_import_action() {
             // 动作行与真实 shell 行必须一眼分得开：文件夹口 = 「去别处拿」。
-            Icon::new(IconName::FolderOpen).xsmall().into_any_element()
+            Icon::new(IconName::FolderOpen).size(px(size * FALLBACK_ICON_SCALE)).into_any_element()
         } else {
-            Icon::new(IconName::SquareTerminal).xsmall().into_any_element()
+            // 没有品牌贴图的 shell 沿用旧壳那张按 id 取字的 Nerd Font 表
+            // （`icon_for_id`，设置行/命令面板同一口径）。字号按回落字形的
+            // 墨迹比例配平：品牌 PNG 的可见部分是自己边长的约 0.77（12%
+            // 安全边距），codicon terminal 的墨迹约 0.88 em——乘 0.88 之后
+            // 两种图标才真的同尺寸。
+            div()
+                .font_family(crate::font_install::REQUIRED_FONT_FAMILY)
+                .text_size(px(size * FALLBACK_ICON_SCALE))
+                .child(crate::shell_detect::icon_for_id(&self.id))
+                .into_any_element()
         };
         h_flex()
             .gap_2()
             .items_center()
-            .child(icon)
-            .child(div().flex_1().min_w_0().child(self.name.clone()))
+            // 图标槽固定成同一个边长，绝不随图标种类伸缩：gpui-component 的
+            // `List` 只量首行（这里是「导入终端目录」动作行）的高度，再拿它
+            // 排所有行；品牌 PNG 有 24px、回落图标只有 xsmall，混排时高行会
+            // 溢出自己的槽位，压住上下相邻行（选中高亮错位就是这么来的）。
+            .child(
+                div()
+                    .size(px(size))
+                    .flex_shrink_0()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .child(icon),
+            )
+            .child(div().flex_1().min_w_0().truncate().child(self.name.clone()))
             .into_any_element()
     }
 }
@@ -171,7 +207,14 @@ impl SelectItem for ShellSelectItem {
 
     fn render(&self, _: &mut Window, _: &mut App) -> impl IntoElement {
         // 旧壳 ShellPickerRow 的品牌图标是 24×24 逻辑像素。
-        self.view(24.0, self.row_image.as_ref())
+        let row = div().child(self.view(SHELL_ROW_ICON_SIZE, self.row_image.as_ref()));
+        if self.is_import_action() {
+            // 见 SHELL_ROW_GAP：首行独自垫高，成为所有行的槽高，才谈得上
+            // 「行与行之间有间隔」。
+            row.pb(px(SHELL_ROW_GAP))
+        } else {
+            row
+        }
     }
 
     fn value(&self) -> &Self::Value {

--- a/nebula_app/src/gpui_shell/settings_pane/tests.rs
+++ b/nebula_app/src/gpui_shell/settings_pane/tests.rs
@@ -97,3 +97,65 @@ fn cached_semantic_statuses_render_in_the_current_language() {
     assert_eq!(ssh.text(crate::display::UiLanguage::ZhCn), "正在打开 server.example…");
     assert_eq!(ssh.text(crate::display::UiLanguage::EnUs), "Opening server.example…");
 }
+
+/// 回归锁：默认 Shell 下拉里，真实 shell 行共用同一个图标槽高度，只有置顶的
+/// 「导入终端目录」动作行比它们多出一个行距。
+///
+/// `gpui-component` 的 `List` 只量**首行**的槽高，再拿这个高度排所有行，而它
+/// 的虚拟列表又不支持条目 `gap_y`。所以两个不变量要一起锁住：品牌 PNG 行和
+/// 字形回落行必须等高（否则高行溢出槽位、压住相邻行），动作行必须恰好高出
+/// 一个 `SHELL_ROW_GAP`（否则行与行之间没有间隔）。
+#[cfg(feature = "gpui-test-support")]
+mod shell_row_geometry {
+    use super::*;
+    use gpui::TestAppContext;
+
+    struct ShellRowProbe {
+        rows: Vec<(&'static str, ShellSelectItem)>,
+    }
+
+    impl Render for ShellRowProbe {
+        fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            // 把继承字号压到图标槽以下，让行高只由图标槽决定。这样断言测的
+            // 就是「行高与图标种类无关」这条不变量本身，而不是某套字体度量。
+            // 走真实的 `SelectItem::render`，连带把动作行的行距一起量进去。
+            v_flex().w(px(240.0)).text_size(px(8.0)).children(self.rows.iter().map(
+                |(selector, item)| {
+                    div()
+                        .debug_selector(move || (*selector).to_owned())
+                        .child(item.render(window, cx))
+                },
+            ))
+        }
+    }
+
+    #[gpui::test]
+    fn every_row_shares_one_icon_slot_height(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let rows = vec![
+            (
+                "shell-probe-import",
+                ShellSelectItem::import_action(crate::display::UiLanguage::ZhCn),
+            ),
+            (
+                "shell-probe-brand",
+                ShellSelectItem::new("pwsh".to_owned(), "PowerShell 7".to_owned(), 1.0),
+            ),
+            ("shell-probe-glyph", ShellSelectItem::new("zsh".to_owned(), "Zsh".to_owned(), 1.0)),
+        ];
+        let (_, cx) = cx.add_window_view(|_, _| ShellRowProbe { rows });
+        let heights: Vec<f32> = ["shell-probe-import", "shell-probe-brand", "shell-probe-glyph"]
+            .iter()
+            .map(|selector| {
+                f32::from(cx.debug_bounds(selector).expect("shell row bounds").size.height)
+            })
+            .collect();
+        assert_eq!(heights[1], heights[2], "品牌图标行与字形回落行必须等高: {heights:?}");
+        assert_eq!(heights[1], SHELL_ROW_ICON_SIZE, "普通行的图标槽即整行高度: {heights:?}");
+        assert_eq!(
+            heights[0],
+            heights[1] + SHELL_ROW_GAP,
+            "动作行必须恰好比普通行多一个行距，这个差值就是所有行的间距: {heights:?}"
+        );
+    }
+}

--- a/nebula_app/src/gpui_shell/workspace.rs
+++ b/nebula_app/src/gpui_shell/workspace.rs
@@ -811,6 +811,17 @@ fn settings_should_fold_sidebar(tabs_position: nebula_settings::TabsPositionName
     tabs_position == nebula_settings::TabsPositionName::Sidebar
 }
 
+/// shell 行的回落字形：没有品牌贴图时用 `shell_detect::icon_for_id` 的
+/// id-keyed Nerd Font 字形（与设置页下拉、命令面板同一口径）。
+///
+/// `has_brand` 为真时返回 `None`——贴图已经画了，两个都留同行会出现两个图标。
+fn fallback_shell_glyph(id: &str, has_brand: bool) -> Option<char> {
+    if has_brand {
+        return None;
+    }
+    crate::shell_detect::icon_for_id(id).chars().next()
+}
+
 /// 新建终端弹窗的行：已检测 shell + SSH 主机，分组对照旧壳
 /// `CommandPalette::open_profiles`（推荐 / 所有 Shell / SSH 主机）。
 /// 三点菜单与 Ctrl+K 打开的是这份列表，不是通用命令面板。
@@ -830,6 +841,14 @@ fn shell_palette_rows(
         .into_iter()
         .map(|shell| {
             let is_default = shell.id == default_shell_id;
+            let icon = crate::gpui_shell::widgets::shell_brand_image(
+                &shell.id,
+                SHELL_ICON_PX,
+                scale_factor,
+            );
+            // 没有品牌贴图的 shell（zsh、csh、ksh…）不能就这么空着：回落到
+            // 按 id 取字的 Nerd Font 字形，与设置页下拉同一口径。
+            let icon_glyph = fallback_shell_glyph(&shell.id, icon.is_some());
             WorkspacePaletteRow {
                 group_order: if is_default { 0 } else { 1 },
                 group: if is_default { recommended.to_owned() } else { all_shells.to_owned() },
@@ -837,12 +856,8 @@ fn shell_palette_rows(
                 hint: shell.program.clone(),
                 hint_style: WorkspacePaletteHintStyle::Metadata,
                 search: format!("{} {} shell profile", shell.name, shell.id).to_lowercase(),
-                icon: crate::gpui_shell::widgets::shell_brand_image(
-                    &shell.id,
-                    SHELL_ICON_PX,
-                    scale_factor,
-                ),
-                icon_glyph: None,
+                icon,
+                icon_glyph,
                 icon_path: None,
                 action: WorkspacePaletteAction::LaunchShell(shell),
             }
@@ -854,6 +869,8 @@ fn shell_palette_rows(
         let icon_id = profile.shell_id.as_deref().unwrap_or(&id);
         let icon =
             crate::gpui_shell::widgets::shell_brand_image(icon_id, SHELL_ICON_PX, scale_factor);
+        // 借用在 `profile` 被移进 action 之前结束。
+        let icon_glyph = fallback_shell_glyph(icon_id, icon.is_some());
         let label = profile.name.clone();
         let hint = profile.command.clone();
         Some(WorkspacePaletteRow {
@@ -865,8 +882,8 @@ fn shell_palette_rows(
             hint,
             hint_style: WorkspacePaletteHintStyle::Metadata,
             action: WorkspacePaletteAction::LaunchProfile(profile),
+            icon_glyph,
             icon,
-            icon_glyph: None,
             icon_path: None,
         })
     }));

--- a/nebula_app/src/gpui_shell/workspace/palette.rs
+++ b/nebula_app/src/gpui_shell/workspace/palette.rs
@@ -1,5 +1,19 @@
 use super::*;
 
+/// 命令面板 / Shell 选择弹窗里图标轨的逻辑边长。品牌贴图、Nerd Font 字形
+/// 与组件库线性图标都排进同一个槽，行与行之间才不会有的缩进有的不缩进。
+const PALETTE_ICON_PX: f32 = 22.0;
+
+/// 非 shell 行（SSH 主机等）的字形字号。shell 行另有配平后的字号，见
+/// `shell_glyph_size`。
+const PALETTE_GLYPH_PX: f32 = 16.0;
+
+/// shell 行字形的字号：与品牌贴图按同一视觉尺寸配平（`shell_detect` 的
+/// 安全边距/墨迹比例是这条换算的唯一出处）。
+fn shell_glyph_size() -> f32 {
+    PALETTE_ICON_PX * crate::shell_detect::FALLBACK_ICON_SCALE
+}
+
 impl NebulaWorkspace {
     pub(super) fn render_command_palette(&mut self, cx: &mut Context<Self>) -> gpui::AnyElement {
         use crate::display::ui::tokens::{control, radius, space};
@@ -103,20 +117,31 @@ impl NebulaWorkspace {
             let icon_content = if let Some(image) = item.icon.clone() {
                 Some(
                     gpui::StyledImage::object_fit(
-                        img(image).size(px(22.0)),
+                        img(image).size(px(PALETTE_ICON_PX)),
                         gpui::ObjectFit::Contain,
                     )
                     .into_any_element(),
                 )
             } else if let Some(glyph) = item.icon_glyph {
+                // shell 行没有品牌贴图时画的是同一个 id-keyed 字形，字号要
+                // 跟品牌贴图配平；SSH 主机等行保持原来的字号。
+                let glyph_px = if matches!(
+                    &item.action,
+                    WorkspacePaletteAction::LaunchShell(_)
+                        | WorkspacePaletteAction::LaunchProfile(_)
+                ) {
+                    shell_glyph_size()
+                } else {
+                    PALETTE_GLYPH_PX
+                };
                 Some(
                     div()
-                        .size(px(22.0))
+                        .size(px(PALETTE_ICON_PX))
                         .flex()
                         .items_center()
                         .justify_center()
                         .font_family(crate::font_install::REQUIRED_FONT_FAMILY)
-                        .text_size(px(16.0))
+                        .text_size(px(glyph_px))
                         .text_color(foreground)
                         .child(glyph.to_string())
                         .into_any_element(),
@@ -124,7 +149,7 @@ impl NebulaWorkspace {
             } else {
                 item.icon_path.clone().map(|path| {
                     div()
-                        .size(px(22.0))
+                        .size(px(PALETTE_ICON_PX))
                         .flex()
                         .items_center()
                         .justify_center()
@@ -133,8 +158,12 @@ impl NebulaWorkspace {
                 })
             };
             let icon_slot = has_icon_rail.then(|| {
-                let slot =
-                    div().size(px(22.0)).flex_shrink_0().flex().items_center().justify_center();
+                let slot = div()
+                    .size(px(PALETTE_ICON_PX))
+                    .flex_shrink_0()
+                    .flex()
+                    .items_center()
+                    .justify_center();
                 match icon_content {
                     Some(icon) => slot.child(icon).into_any_element(),
                     None => slot.into_any_element(),

--- a/nebula_app/src/gpui_shell/workspace/tests.rs
+++ b/nebula_app/src/gpui_shell/workspace/tests.rs
@@ -581,6 +581,50 @@ fn shell_palette_puts_the_default_shell_first() {
     assert_eq!(rows[0].group, "所有 Shell");
 }
 
+/// 回归锁：新建终端弹窗里，没有品牌贴图的 shell 不能空着——必须回落到按 id
+/// 取字的 Nerd Font 字形。之前这一列只填了 `icon`，于是 zsh、csh、ksh 这些
+/// 整行左边什么都没有。
+#[test]
+fn shell_palette_falls_back_to_an_id_glyph_when_brand_art_is_absent() {
+    let shells = ["zsh", "csh", "ksh", "bash", "pwsh"]
+        .into_iter()
+        .map(|id| crate::shell_detect::DetectedShell {
+            name: crate::shell_detect::display_name_for_id(id),
+            id: id.to_owned(),
+            program: format!("/bin/{id}"),
+            args: Vec::new(),
+        })
+        .collect::<Vec<_>>();
+    let rows = shell_palette_rows(
+        shells,
+        Vec::new(),
+        None::<String>,
+        "zsh",
+        crate::display::UiLanguage::ZhCn,
+        1.0,
+    );
+    let mut brandless = 0;
+    for row in &rows {
+        let WorkspacePaletteAction::LaunchShell(shell) = &row.action else { continue };
+        assert_eq!(
+            row.icon.is_none(),
+            row.icon_glyph.is_some(),
+            "`{}` 必须恰好有一种图标来源（品牌贴图或回落字形）",
+            shell.id
+        );
+        if row.icon.is_none() {
+            brandless += 1;
+            assert_eq!(
+                row.icon_glyph,
+                crate::shell_detect::icon_for_id(&shell.id).chars().next(),
+                "`{}` 的回落字形要与共享图标口径一致",
+                shell.id
+            );
+        }
+    }
+    assert!(brandless >= 3, "zsh/csh/ksh 都没有品牌贴图，都要有字形: {brandless}");
+}
+
 #[test]
 fn shell_palette_includes_imported_terminal_profiles() {
     let profile = crate::config::ui_config::Profile {

--- a/nebula_app/src/shell_detect.rs
+++ b/nebula_app/src/shell_detect.rs
@@ -94,6 +94,12 @@ impl DetectedShell {
 /// Nerd Font glyph for a shell id — shared by detected shells and the settings
 /// row so a saved `shell=<id>` always draws the same mark. WSL distro ids carry
 /// a `wsl:` prefix; everything else matches whole.
+///
+/// Shells without brand artwork (zsh, sh, dash, csh, ksh, tcsh…) all share the
+/// one `cod-terminal` codepoint. Different Nerd Font glyphs carry very
+/// different ink for the same em (dev-terminal is ~0.7 em, codicon ~0.9), so
+/// mixing them in one dropdown renders at visibly different sizes; a single
+/// codepoint is what makes "every icon the same size" true by construction.
 pub fn icon_for_id(id: &str) -> &'static str {
     let id = profile_shell_id(id).unwrap_or(id).to_ascii_lowercase();
     if id.starts_with("wsl") {
@@ -102,11 +108,16 @@ pub fn icon_for_id(id: &str) -> &'static str {
     match id.as_str() {
         "pwsh" | "powershell" => "\u{ebc7}", // codicon terminal-powershell
         "cmd" => "\u{ebc4}",                 // codicon terminal-cmd
-        "bash" | "git-bash" | "gitbash" | "zsh" | "sh" | "dash" => "\u{e795}", // devicon bash/terminal
-        "fish" | "nu" => "\u{f489}", // generic terminal glyph
-        _ => "\u{ea85}",             // codicon terminal (fallback)
+        _ => "\u{ea85}",                     // codicon terminal (every other shell)
     }
 }
+
+/// 回落字形相对图标槽边长的字号系数。
+///
+/// 品牌 PNG 是从矢量图按 12% 安全边距栅格化的，可见部分约为自身边长的
+/// 0.77；`icon_for_id` 返回的 codicon terminal 墨迹约 0.88 em。两者乘上这
+/// 个系数之后才在视觉上是同一个尺寸——不乘就会「有的图标大、有的小」。
+pub const FALLBACK_ICON_SCALE: f32 = 0.88;
 
 /// Full-color brand icon (embedded PNG, rasterized from vector artwork with
 /// a 12% safe margin; see THIRD-PARTY-NOTICES) for a shell id — the terminal picker draws this textured
@@ -1058,6 +1069,21 @@ mod tests {
         let profile_key = "profile:pwsh|pwsh-1234";
         assert_eq!(icon_for_id(profile_key), icon_for_id("pwsh"));
         assert!(color_icon_png(profile_key).is_some());
+    }
+
+    /// 回归锁：没有品牌贴图的 shell 必须共用同一个字形码位。下拉把它们排在同
+    /// 一槽位、同一字号；混用不同 Nerd 码位时墨迹大小差很多（dev-terminal
+    /// 约 0.7 em，codicon 约 0.9），看起来就是「有的图标大、有的小」。
+    #[test]
+    fn fallback_shell_marks_share_one_glyph_so_they_render_at_one_size() {
+        let expected = icon_for_id("zsh");
+        for id in ["zsh", "sh", "dash", "csh", "ksh", "tcsh", "fish", "nu", "unknown-shell"] {
+            assert_eq!(icon_for_id(id), expected, "`{id}` 的回落字形必须与其它 shell 一致");
+        }
+        // 有品牌贴图的仍然保留各自的字形：贴图取不到时（导入的 profile 家族）
+        // 也不该和 POSIX shell 混成同一个印记。
+        assert_ne!(icon_for_id("pwsh"), expected);
+        assert_ne!(icon_for_id("cmd"), expected);
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## Result / 用户结果

- Settings → 终端 的「默认 Shell」下拉里，图标有三种尺寸：品牌 PNG 24px、`dev-terminal` 字形约 0.7em、`cod-terminal` 字形约 0.9em；选中行还紧贴上一行，没有间隔。
- 三点 / Ctrl+K 的新终端弹窗里，没有品牌贴图的 shell（zsh、csh、ksh、sh、dash、tcsh）整行左边**没有图标**。

现在两个界面都回落到共享的 id-keyed 字形（`shell_detect::icon_for_id`），并按 `FALLBACK_ICON_SCALE` 配平到与品牌贴图同一视觉尺寸；设置下拉的图标槽固定为同一 `SHELL_ROW_ICON_SIZE`，行间距由 `SHELL_ROW_GAP` 提供。

无关联 issue：本地实测发现。

## Design / 设计边界

- **Responsibility and affected modules:** 字形与配平系数留在 `nebula_app/src/shell_detect.rs`（图标权威，旧壳与命令面板共用）；两个消费者 `gpui_shell/settings_pane/shell_picker.rs`、`gpui_shell/workspace.rs` + `gpui_shell/workspace/palette.rs` 只做适配。
- **Why this belongs here:** `icon_for_id` 的文档本来就声明它 *shared by detected shells and the settings row so a saved `shell=<id>` always draws the same mark*；此前 GPUI 的两个界面一个没用它、一个只画品牌贴图。`color_icon_png` / `icon_for_id` / 持久化 id 语义不变。
- **Dependency, data-format, threading, or lifetime changes:** 无。
- **Compatibility and fallback behavior:** 有品牌贴图的 shell 行为不变；没有的从「无图标 / 异尺寸」变成统一的 id-keyed 字形。`icon_for_id` 把无品牌资产的 shell 统一到 `cod-terminal`（`U+EA85`），有品牌资产的（pwsh / cmd）保留各自码位。

## Evidence / 验证依据

- 命令与结果：`cargo test ... -- shell_row_geometry shell_palette shell_detect::` → **20 passed / 0 failed**。
- Regression（修复前会红）：
  - `shell_row_geometry::every_row_shares_one_icon_slot_height` —— 修复前实测 `[13.0, 24.0, 13.0]`（品牌行 24px，动作行与字形行 13px，这正是行背景溢出、叠到相邻行的来源）。现在断言 品牌行 == 字形行 == `SHELL_ROW_ICON_SIZE`，且动作行恰好高出 `SHELL_ROW_GAP`。
  - `shell_palette_falls_back_to_an_id_glyph_when_brand_art_is_absent` —— 每个 shell 行恰好一种图标来源；无贴图行必须带 id 字形。
  - `fallback_shell_marks_share_one_glyph_so_they_render_at_one_size` —— 所有无品牌 shell 共用一个码位。
- 行间距的实现依赖组件库「只量首行槽高、再拿它排所有行」且虚拟列表没有 `gap_y`（`crates/ui/src/list/list.rs` 注释明说）。这是唯一不 fork 组件库的着力点，已在常量文档中写明。
- 未运行：`python3 scripts/check_architecture.py --base c2deb16`（本机 Python 3.9.6，检查器要求 3.11+）。人工确认无文件超预算、无新增依赖边。
- 仅验证 macOS 构建；Windows 分支未改，未在 Windows 运行。
- 未做打包应用验证。

## Required Review / 必须确认

- [x] 已遵循 `CONTRIBUTING.md`、`docs/architecture.md`、`docs/project-constraints.md`。
- [x] 按职责拆分，未新增重复的行为权威。
- [x] `scripts/check_architecture.py` 未能运行（环境缺 Python 3.11+，见上）；未抬高任何预算。
- [x] 有回归测试；平台覆盖限制已说明。
- [x] 无新增 UI 文案。
- [x] 无治理变更。

*与另外两个 PR（默认 Shell 解析、通知溢出）无文件冲突：同文件的改动落在不同区域，任意顺序合并均可。*
