### PR TITLE
fix(toast): bound notification height so long agent messages can't cover the UI

### DIFF
--- a/nebula_app/src/gpui_shell/toast.rs
+++ b/nebula_app/src/gpui_shell/toast.rs
@@ -79,6 +79,11 @@ fn is_duplicate(text: &str) -> bool {
 }
 
 fn note(kind: ToastKind, text: String) -> Notification {
+    // 通知栏是「一眼带过」的层。正文先收短：模型回合完成的正文可能是整段
+    // 回答（OSC 9 更是无界），不设上限时按固定宽度排出来比窗口还高，锚在
+    // 右下就会整条溢出屏幕、把关闭按钮顶到看不见的地方。完整原文仍在日志
+    // 与终端的「阅读 / 原文」里。
+    let text = crate::notify::clamp_toast_body(&text);
     let note = match kind {
         ToastKind::Info => Notification::info(text),
         ToastKind::Success => Notification::success(text),
@@ -132,6 +137,10 @@ pub fn render_layer(window: &mut Window, cx: &mut App) -> Option<AnyElement> {
             .items_end()
             .justify_end()
             .p(px(20.0))
+            // 硬保证：任何一条通知都不可能画到窗口之外。正文长度已在
+            // [`note`] 收短，这里是兜底——溢出到屏幕外的卡片连关闭按钮都
+            // 够不着。
+            .overflow_hidden()
             // 用全视口透明宿主明确右下锚点；宿主不注册命中，只有实际
             // Notification 卡片会 occlude/接收鼠标，周围终端仍可正常点击。
             .child(v_flex().items_end().gap_2().children(items))
@@ -151,13 +160,17 @@ pub fn toast(window: &mut Window, cx: &mut App, kind: ToastKind, text: impl Into
 
 /// 驻留一条消息（消息栏层）：停留远长于 toast，但**有上限**，见
 /// [`BANNER_TTL`]。用于「值得驻留」的事——没什么值得驻留的请用 [`toast`]。
+///
+/// 这里也挂一个空的 `on_click`：组件库的点击包装会先 `dismiss` 再调回调，
+/// 所以整张卡片点一下就消失。驻留消息的关闭按钮只在悬停时出现，没有这条
+/// 路径的话「怎么都关不掉」就是字面事实。
 pub fn banner(window: &mut Window, cx: &mut App, kind: ToastKind, text: impl Into<String>) {
     let text = text.into();
     if text.trim().is_empty() {
         return;
     }
     log::warn!("banner [{kind:?}]: {text}");
-    push_banner(window, cx, note(kind, text));
+    push_banner(window, cx, note(kind, text).on_click(|_, _, _| {}));
 }
 
 pub(crate) fn banner_for_pane(

--- a/nebula_app/src/notify.rs
+++ b/nebula_app/src/notify.rs
@@ -106,10 +106,38 @@ pub enum Notification {
     AiTurn { program: String, message: Option<String>, attention: bool },
 }
 
+/// Longest notification body any shell may render.
+///
+/// A toast/banner is a glance layer, not a reader. Codex's turn-complete
+/// notification carries the model's `last-assistant-message` (bounded only at
+/// 4 000 chars in `ai_hook`), and an OSC 9 body is unbounded; rendered at a
+/// fixed width that becomes a card taller than the window. Anchored to the
+/// bottom-right it then overflows off the top, taking its close button out of
+/// reach, and sits there for the whole banner TTL while covering whatever is
+/// underneath (including a split pane). Only the preview is bounded here — the
+/// full text stays in the log and in the terminal's answer reader.
+pub(crate) const TOAST_BODY_MAX_CHARS: usize = 160;
+
+/// Clamp a notification body to [`TOAST_BODY_MAX_CHARS`], ending with `…` when
+/// anything was dropped. The ellipsis replaces the last kept character, so the
+/// result never exceeds the limit and clamping again is a no-op.
+pub(crate) fn clamp_toast_body(body: &str) -> String {
+    if body.chars().count() <= TOAST_BODY_MAX_CHARS {
+        return body.to_owned();
+    }
+    let head: String = body.chars().take(TOAST_BODY_MAX_CHARS - 1).collect();
+    format!("{head}…")
+}
+
 impl Notification {
     /// Toast title + body. Title names the source ("Pebrel" or the program);
-    /// body carries the human detail.
+    /// body carries the human detail, bounded to a glanceable length.
     pub(crate) fn toast_text(&self) -> (String, String) {
+        let (title, body) = self.raw_toast_text();
+        (title, clamp_toast_body(&body))
+    }
+
+    fn raw_toast_text(&self) -> (String, String) {
         match self {
             Self::Bell { program } => match program {
                 Some(p) => (p.clone(), "任务完成，等待输入".to_owned()),
@@ -301,6 +329,32 @@ mod delivery_tests {
         assert!(
             !Notification::Text { body: "permission".to_owned(), program: None }.is_attention()
         );
+    }
+
+    /// 回归锁：一篇很长的模型回答不能变成一张撑破窗口的通知卡。正文只保留
+    /// 一眼能读的预览，其余在日志和终端「原文」里。
+    #[test]
+    fn oversized_notification_bodies_are_clamped_to_a_glanceable_preview() {
+        let long = "回答正文。".repeat(1_000);
+        let done = Notification::AiTurn {
+            program: "codex".to_owned(),
+            message: Some(long.clone()),
+            attention: false,
+        };
+        let (title, body) = done.toast_text();
+        assert_eq!(title, "codex");
+        assert!(body.chars().count() <= TOAST_BODY_MAX_CHARS, "正文必须被收短: {}", body.len());
+        assert!(body.ends_with('…'), "被截断的正文要以省略号收尾");
+        assert!(long.starts_with(body.trim_end_matches('…')), "保留的是原文开头");
+
+        // OSC 9 原文同样无界，走 Text 分支也要收短。
+        let (_, osc) =
+            Notification::Text { body: long, program: Some("claude".to_owned()) }.toast_text();
+        assert!(osc.chars().count() <= TOAST_BODY_MAX_CHARS);
+
+        // 幂等：已经收短过的正文再收一次不会多出第二个省略号。
+        let once = clamp_toast_body(&"x".repeat(1_000));
+        assert_eq!(clamp_toast_body(&once), once);
     }
 
     #[cfg(feature = "gpui-shell")]


### PR DESCRIPTION
## Result / 用户结果

模型回复较长时，驻留通知会长到比窗口还高：它锚在右下、向上溢出屏幕，把只在悬停时出现的关闭按钮顶出可视区，并在整个 90s 驻留期内盖住右侧分屏（设置页也照盖，因为通知层挂在 workspace 根的最外层）。

现在：

- 通知正文收短成一眼可读的预览（完整原文仍在日志与终端「阅读 / 原文」）；
- 通知层裁剪到窗口内，任何一条都不会画到屏幕外；
- 普通驻留消息支持点击卡片任意处关闭（此前只有悬停才出现的 `×`）。

无关联 issue：本地实测发现。

## Design / 设计边界

- **Responsibility and affected modules:** 显示长度的唯一权威在 `nebula_app/src/notify.rs`（`TOAST_BODY_MAX_CHARS` / `clamp_toast_body`）。两个消费点：`Notification::toast_text()`（两个壳共用，含系统通知）与 GPUI 显示层 `gpui_shell/toast.rs::note()`（覆盖不走 `toast_text` 的来源）。
- **Why this belongs here:** `toast_text()` 是两个壳共用的通知文本出口；clamp 是 `toast.rs` 模块文档既有约定「通知是 glance 层、不作为唯一副本」的延伸——全文仍在日志与 answer reader。`Notification` 的种类、`toast_text` 的 title/body 形状、`BANNER_TTL` 都不变。
- **Dependency, data-format, threading, or lifetime changes:** 无。
- **Compatibility and fallback behavior:** 短消息逐字不变；被截断的正文以 `…` 收尾。点击关闭复用组件库 `on_click` 包装（先 `dismiss` 再回调），不新增自有状态机。

## Evidence / 验证依据

- 命令与结果：`cargo test ... -- notify::` → **5 passed / 0 failed**。
- Regression `oversized_notification_bodies_are_clamped_to_a_glanceable_preview`：4 000 字的 `AiTurn` 正文与无界 OSC 9 正文都被收进 `TOAST_BODY_MAX_CHARS`、以省略号收尾、保留原文开头，且幂等（二次 clamp 不变）。
- 全量 bin 单测：**1144 passed / 1 failed**。唯一失败为既有用例 `tab_rename_paste_tests::focused_tab_rename_ctrl_v_reaches_input_without_pasting_terminal`，在干净 `main` 上同样失败（macOS 剪贴板行为），与本改动无关。
- 触发链（供复核）：codex `agent-turn-complete` 的 `last-assistant-message` 在 `ai_hook.rs` 只按 4 000 字截断 → `Notification::AiTurn.message` → `toast_text()` 原样输出 → 固定宽 440px、无高度上限的卡片 → 右下锚点向上溢出。
- 未运行：`python3 scripts/check_architecture.py --base c2deb16`（本机 Python 3.9.6，检查器要求 3.11+）。人工确认无文件超预算、无新增依赖边。
- 未做打包应用验证。

## Required Review / 必须确认

- [x] 已遵循 `CONTRIBUTING.md`、`docs/architecture.md`、`docs/project-constraints.md`。
- [x] 按职责拆分，未新增重复的行为权威。
- [x] `scripts/check_architecture.py` 未能运行（环境缺 Python 3.11+，见上）；未抬高任何预算。
- [x] 有回归测试；平台覆盖限制已说明。
- [x] 无新增 UI 文案。
- [x] 无治理变更。

*与本会话另外两个 PR（默认 Shell 解析、shell 图标尺寸与行间距）无文件交集。*
